### PR TITLE
LC Classification Step - Schemaless Producer

### DIFF
--- a/lc_classification_step/lc_classification/core/parsers/elasticc_parser.py
+++ b/lc_classification_step/lc_classification/core/parsers/elasticc_parser.py
@@ -2,7 +2,6 @@ from ..utils.no_class_post_processor import (
     NoClassifiedPostProcessor,
 )
 from .kafka_parser import KafkaOutput, KafkaParser
-from lc_classification.predictors.predictor.predictor_parser import PredictorOutput
 from lc_classification.core.parsers.classes.elasticc_mapper import ClassMapper
 from alerce_classifiers.base.dto import OutputDTO
 import pandas as pd
@@ -35,8 +34,8 @@ class ElasticcParser(KafkaParser):
                 "elasticcPublishTimestamp": new_detection["extra_fields"].get(
                     "timestamp"
                 ),
-                "brokerIngestTimestamp": new_detection["extra_fields"].get(
-                    "brokerIngestTimestamp"
+                "brokerIngestTimestamp": int(
+                    new_detection["extra_fields"].get("brokerIngestTimestamp")
                 ),
             }
         predictions = model_output.probabilities
@@ -81,9 +80,6 @@ class ElasticcParser(KafkaParser):
                 "classifierName": classifier_name,
                 "classifierParams": classifier_version,
                 "brokerName": "ALeRCE",
-                "brokerPublishTimestamp": int(
-                    datetime.datetime.now().timestamp() * 1000
-                ),
             }
             output.append(response)
         return KafkaOutput(output)

--- a/lc_classification_step/schemas.py
+++ b/lc_classification_step/schemas.py
@@ -258,59 +258,6 @@ SCHEMA = {
     ],
 }
 
-ELASTICC_SCHEMA = {
-    "namespace": "elasticc.v0_9",
-    "type": "record",
-    "name": "brokerClassification",
-    "doc": "sample avro alert schema v4.1",
-    "fields": [
-        {"name": "alertId", "type": "long", "doc": "unique alert identifer"},
-        {
-            "name": "diaSourceId",
-            "type": "long",
-            "doc": "id of source that triggered this classification",
-        },
-        {
-            "name": "brokerName",
-            "type": "string",
-            "doc": "Name of broker (never changes)",
-        },
-        {
-            "name": "brokerVersion",
-            "type": "string",
-            "doc": "Version/Release of broker's software",
-        },
-        {
-            "name": "classifierName",
-            "type": "string",
-            "doc": "Name of classifier broker is using, including software version",
-        },
-        {
-            "name": "classifierParams",
-            "type": "string",
-            "doc": "Any classifier parameter information worth noting for this classification",
-        },
-        {
-            "name": "classifications",
-            "type": {
-                "type": "array",
-                "items": {
-                    "type": "record",
-                    "name": "classificationDict",
-                    "fields": [
-                        {
-                            "name": "classId",
-                            "type": "int",
-                            "doc": "See https://github.com/LSSTDESC/elasticc/tree/main/taxonomy/taxonomy.ipynb for specification",
-                        },
-                        {"name": "probability", "type": "float", "doc": "0-1"},
-                    ],
-                },
-            },
-        },
-    ],
-}
-
 
 SCRIBE_SCHEMA = {
     "type": "record",

--- a/lc_classification_step/schemas/output_elasticc.avsc
+++ b/lc_classification_step/schemas/output_elasticc.avsc
@@ -1,0 +1,78 @@
+{
+  "namespace": "elasticc.v0_9_1",
+  "type": "record",
+  "name": "brokerClassfication",
+  "fields": [
+    {
+      "name": "alertId",
+      "type": "long",
+      "doc": "unique alert identifer"
+    },
+    {
+      "name": "diaSourceId",
+      "type": "long",
+      "doc": "id of source that triggered this classification"
+    },
+    {
+      "name": "elasticcPublishTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "timestamp from originating ELAsTiCC alert"
+    },
+    {
+      "name": "brokerIngestTimestamp",
+      "type": [
+        "null",
+        {
+          "type": "long",
+          "logicalType": "timestamp-millis"
+        }
+      ],
+      "doc": "timestamp of broker ingestion of ELAsTiCC alert"
+    },
+    {
+      "name": "brokerName",
+      "type": "string",
+      "doc": "Name of broker (never changes)"
+    },
+    {
+      "name": "brokerVersion",
+      "type": "string",
+      "doc": "Version/Release of broker's software"
+    },
+    {
+      "name": "classifierName",
+      "type": "string",
+      "doc": "Name of classifier broker is using, including software version"
+    },
+    {
+      "name": "classifierParams",
+      "type": "string",
+      "doc": "Any classifier parameter information worth noting for this classification"
+    },
+    {
+      "name": "classifications",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "classificationDict",
+          "fields": [
+            {
+              "name": "classId",
+              "type": "int",
+              "doc": "See https://github.com/LSSTDESC/elasticc/tree/main/taxonomy/taxonomy.ipynb for specification"
+            },
+            {
+              "name": "probability",
+              "type": "float",
+              "doc": "0-1"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/lc_classification_step/settings.py
+++ b/lc_classification_step/settings.py
@@ -2,8 +2,10 @@
 #       Late Classifier Settings File
 ##################################################
 import os
-from schemas import SCHEMA, ELASTICC_SCHEMA, SCRIBE_SCHEMA
+from schemas import SCHEMA, SCRIBE_SCHEMA
 from predictor_settings import configurator
+from fastavro.schema import load_schema
+from fastavro.repository.base import SchemaRepositoryError
 
 CONSUMER_CONFIG = {
     "CLASS": os.getenv("CONSUMER_CLASS", "apf.consumers.KafkaConsumer"),
@@ -18,6 +20,10 @@ CONSUMER_CONFIG = {
     "consume.messages": int(os.getenv("CONSUME_MESSAGES", 1000)),
 }
 
+try:
+    ELASTICC_SCHEMA = load_schema("schemas/output_elasticc.avsc")
+except SchemaRepositoryError:
+    ELASTICC_SCHEMA = load_schema("lc_classification_step/schemas/output_elasticc.avsc")
 PRODUCER_CONFIG = {
     "TOPIC_STRATEGY": {
         "PARAMS": {
@@ -34,7 +40,7 @@ PRODUCER_CONFIG = {
     "PARAMS": {
         "bootstrap.servers": os.environ["PRODUCER_SERVER"],
     },
-    "CLASS": os.getenv("KAFKA_PRODUCER_CLASS"),
+    "CLASS": os.getenv("PRODUCER_CLASS", "apf.producers.kafka.KafkaProducer"),
     "SCHEMA": SCHEMA if os.getenv("STREAM", "ztf") == "ztf" else ELASTICC_SCHEMA,
 }
 

--- a/lc_classification_step/settings.py
+++ b/lc_classification_step/settings.py
@@ -34,7 +34,7 @@ PRODUCER_CONFIG = {
     "PARAMS": {
         "bootstrap.servers": os.environ["PRODUCER_SERVER"],
     },
-    "CLASS": "apf.producers.KafkaProducer",
+    "CLASS": os.getenv("KAFKA_PRODUCER_CLASS"),
     "SCHEMA": SCHEMA if os.getenv("STREAM", "ztf") == "ztf" else ELASTICC_SCHEMA,
 }
 

--- a/lc_classification_step/tests/integration/conftest.py
+++ b/lc_classification_step/tests/integration/conftest.py
@@ -50,6 +50,7 @@ def is_responsive_kafka(url):
             NewTopic("w_object", num_partitions=1),
             NewTopic(get_lc_classifier_topic("ztf"), num_partitions=1),
             NewTopic(get_lc_classifier_topic("balto"), num_partitions=1),
+            NewTopic(get_lc_classifier_topic("balto_schemaless"), num_partitions=1),
             NewTopic(get_lc_classifier_topic("messi"), num_partitions=1),
             NewTopic(get_lc_classifier_topic("toretto"), num_partitions=1),
             NewTopic(get_lc_classifier_topic("barney"), num_partitions=1),

--- a/lc_classification_step/tests/integration/conftest.py
+++ b/lc_classification_step/tests/integration/conftest.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import pytest
 from apf.consumers import KafkaConsumer
 from apf.producers import KafkaProducer
+from apf.core import get_class
 from confluent_kafka.admin import AdminClient, NewTopic
 from fastavro.utils import generate_many
 
@@ -137,7 +138,6 @@ def env_variables_elasticc():
             "STEP_PARSER_CLASS": "lc_classification.core.parsers.elasticc_parser.ElasticcParser",
         }
         env_variables_dict.update(extra_env_vars)
-        print(env_variables_dict)
         for key, value in env_variables_dict.items():
             os.environ[key] = value
 
@@ -167,21 +167,26 @@ def produce_messages(topic, SCHEMA):
 
 @pytest.fixture(scope="session")
 def kafka_consumer():
-    def factory(stream: str):
-        consumer = KafkaConsumer(
-            {
-                "PARAMS": {
-                    "bootstrap.servers": "localhost:9092",
-                    "group.id": f"test_steppu{time.time()}",
-                    "auto.offset.reset": "beginning",
-                    "enable.partition.eof": True,
-                },
-                "TOPICS": [
-                    get_lc_classifier_topic(stream),
-                ],
-                "TIMEOUT": 0,
-            }
-        )
+    def factory(
+        stream: str,
+        consumer_class="apf.consumers.kafka.KafkaConsumer",
+        consumer_params={},
+    ):
+        Consumer = get_class(consumer_class)
+        params = {
+            "PARAMS": {
+                "bootstrap.servers": "localhost:9092",
+                "group.id": f"test_steppu{time.time()}",
+                "auto.offset.reset": "beginning",
+                "enable.partition.eof": True,
+            },
+            "TOPICS": [
+                get_lc_classifier_topic(stream),
+            ],
+            "TIMEOUT": 0,
+        }
+        params.update(consumer_params)
+        consumer = Consumer(params)
         return consumer
 
     return factory

--- a/lc_classification_step/tests/integration/test_step_balto.py
+++ b/lc_classification_step/tests/integration/test_step_balto.py
@@ -49,14 +49,14 @@ def test_step_elasticc_result(
 
 
 @pytest.mark.elasticc
-def test_step_schemaless_from_correction(
+def test_step_schemaless(
     kafka_service,
     env_variables_elasticc,
     kafka_consumer: Callable[[str], KafkaConsumer],
     scribe_consumer: Callable[[], KafkaConsumer],
 ):
     env_variables_elasticc(
-        "balto",
+        "balto_schemaless",
         "lc_classification.predictors.balto.balto_predictor.BaltoPredictor",
         "lc_classification.predictors.balto.balto_parser.BaltoParser",
         {
@@ -70,13 +70,13 @@ def test_step_schemaless_from_correction(
 
     try:
         kconsumer = kafka_consumer(
-            "balto",
+            "balto_schemaless",
             "apf.consumers.kafka.KafkaSchemalessConsumer",
             {"SCHEMA_PATH": "schemas/output_elasticc.avsc"},
         )
     except SchemaRepositoryError:
         kconsumer = kafka_consumer(
-            "balto",
+            "balto_schemaless",
             "apf.consumers.kafka.KafkaSchemalessConsumer",
             {"SCHEMA_PATH": "lc_classification_step/schemas/output_elasticc.avsc"},
         )

--- a/lc_classification_step/tests/integration/test_step_balto.py
+++ b/lc_classification_step/tests/integration/test_step_balto.py
@@ -10,6 +10,7 @@ from tests.test_commons import (
     assert_command_is_correct,
     assert_elasticc_object_is_correct,
 )
+from fastavro.repository.base import SchemaRepositoryError
 
 
 @pytest.mark.elasticc
@@ -32,6 +33,53 @@ def test_step_elasticc_result(
     from settings import STEP_CONFIG
 
     kconsumer = kafka_consumer("balto")
+    sconsumer = scribe_consumer()
+
+    step = LateClassifier(config=STEP_CONFIG)
+    step.start()
+
+    for message in kconsumer.consume():
+        assert_elasticc_object_is_correct(message)
+        kconsumer.commit()
+
+    for message in sconsumer.consume():
+        command = json.loads(message["payload"])
+        assert_command_is_correct(command)
+        sconsumer.commit()
+
+
+@pytest.mark.elasticc
+def test_step_schemaless_from_correction(
+    kafka_service,
+    env_variables_elasticc,
+    kafka_consumer: Callable[[str], KafkaConsumer],
+    scribe_consumer: Callable[[], KafkaConsumer],
+):
+    env_variables_elasticc(
+        "balto",
+        "lc_classification.predictors.balto.balto_predictor.BaltoPredictor",
+        "lc_classification.predictors.balto.balto_parser.BaltoParser",
+        {
+            "MODEL_PATH": os.getenv("TEST_BALTO_MODEL_PATH"),
+            "QUANTILES_PATH": os.getenv("TEST_BALTO_QUANTILES_PATH"),
+            "PRODUCER_CLASS": "apf.producers.kafka.KafkaSchemalessProducer",
+        },
+    )
+
+    from settings import STEP_CONFIG
+
+    try:
+        kconsumer = kafka_consumer(
+            "balto",
+            "apf.consumers.kafka.KafkaSchemalessConsumer",
+            {"SCHEMA_PATH": "schemas/output_elasticc.avsc"},
+        )
+    except SchemaRepositoryError:
+        kconsumer = kafka_consumer(
+            "balto",
+            "apf.consumers.kafka.KafkaSchemalessConsumer",
+            {"SCHEMA_PATH": "lc_classification_step/schemas/output_elasticc.avsc"},
+        )
     sconsumer = scribe_consumer()
 
     step = LateClassifier(config=STEP_CONFIG)

--- a/lc_classification_step/tests/test_commons.py
+++ b/lc_classification_step/tests/test_commons.py
@@ -11,13 +11,12 @@ def assert_elasticc_object_is_correct(obj):
     valid_fields = [
         "alertId",
         "diaSourceId",
-        # "elasticcPublishTimestamp",
-        # "brokerIngestTimestamp",
+        "elasticcPublishTimestamp",
+        "brokerIngestTimestamp",
         "classifications",
         "brokerVersion",
         "classifierName",
         "classifierParams",
-        # "brokerPublishTimestamp",
         "brokerName",
     ]
     for field in valid_fields:


### PR DESCRIPTION
- Fixes output schema with correct schema from https://github.com/LSSTDESC/elasticc/blob/main/alert_schema/elasticc.v0_9_1.brokerClassification.avsc
- Allows the option to use both Schemaless or normal producer