### PR TITLE
Fix timestamps

### DIFF
--- a/lc_classification_step/lc_classification/core/parsers/elasticc_parser.py
+++ b/lc_classification_step/lc_classification/core/parsers/elasticc_parser.py
@@ -31,10 +31,10 @@ class ElasticcParser(KafkaParser):
                 "candid": new_detection["candid"],
                 "oid": new_detection["oid"],
                 "elasticcPublishTimestamp": new_detection["extra_fields"].get(
-                    "timestamp"
+                    "surveyPublishTimestamp"
                 ),
-                "brokerIngestTimestamp": self.broker_ingest_timestamp_to_millis(
-                    new_detection["extra_fields"].get("brokerIngestTimestamp")
+                "brokerIngestTimestamp": new_detection["extra_fields"].get(
+                    "brokerIngestTimestamp"
                 ),
             }
         predictions = model_output.probabilities
@@ -68,12 +68,10 @@ class ElasticcParser(KafkaParser):
                 "diaSourceId": int(detection_extra_info[aid]["oid"]),
                 "elasticcPublishTimestamp": detection_extra_info[aid][
                     "elasticcPublishTimestamp"
-                ]
-                * 1000,
+                ],
                 "brokerIngestTimestamp": detection_extra_info[aid][
                     "brokerIngestTimestamp"
-                ]
-                * 1000,
+                ],
                 "classifications": output_classification,
                 "brokerVersion": classifier_version,
                 "classifierName": classifier_name,
@@ -82,6 +80,3 @@ class ElasticcParser(KafkaParser):
             }
             output.append(response)
         return KafkaOutput(output)
-
-    def broker_ingest_timestamp_to_millis(self, timestamp: float):
-        return int(timestamp) * 1000

--- a/lc_classification_step/tests/mockdata/extra_felds.py
+++ b/lc_classification_step/tests/mockdata/extra_felds.py
@@ -76,6 +76,6 @@ def generate_extra_fields():
         diaobject[key] = random.random()
     return {
         "diaObject": pickle.dumps([diaobject]),
-        "timestamp": datetime.datetime.now().timestamp(),
-        "brokerIngestTimestamp": datetime.datetime.now().timestamp(),
+        "surveyIngestTimestamp": int(datetime.datetime.now().timestamp()),
+        "brokerIngestTimestamp": int(datetime.datetime.now().timestamp()),
     }

--- a/libs/survey_parser_plugins/survey_parser_plugins/parsers/ATLASParser.py
+++ b/libs/survey_parser_plugins/survey_parser_plugins/parsers/ATLASParser.py
@@ -57,6 +57,8 @@ class ATLASParser(SurveyParser):
             "cutoutScience",
             "cutoutTemplate",
             "cutoutDifference",
+            "brokerIngestTimestamp",
+            "surveyPublishTimestamp",
         ]
         candidate.update({k: v for k, v in message.items() if k in fields_from_top})
         return super(ATLASParser, cls).parse_message(candidate)

--- a/libs/survey_parser_plugins/survey_parser_plugins/parsers/ZTFParser.py
+++ b/libs/survey_parser_plugins/survey_parser_plugins/parsers/ZTFParser.py
@@ -63,6 +63,8 @@ class ZTFParser(SurveyParser):
             "cutoutScience",
             "cutoutTemplate",
             "cutoutDifference",
+            "brokerIngestTimestamp",
+            "surveyPublishTimestamp",
         ]
         candidate.update({k: v for k, v in message.items() if k in fields_from_top})
         return super(ZTFParser, cls).parse_message(candidate)

--- a/reflector_step/reflector_step/step.py
+++ b/reflector_step/reflector_step/step.py
@@ -52,7 +52,11 @@ class CustomMirrormaker(GenericStep):
     def _produce_single_message(self, message):
         if self.use_message_topic:
             self.producer.topic = [message.topic()]
-        self.producer.produce(message)
+        if self.config["keep_original_timestamp"]:
+            timestamp = message.timestamp()[1]
+        else:
+            timestamp = None
+        self.producer.produce(message, timestamp=timestamp)
 
     def execute(self, message):
         self.produce(message)

--- a/reflector_step/settings.py
+++ b/reflector_step/settings.py
@@ -45,6 +45,10 @@ PRODUCER_CONFIG = {
     "PARAMS": {
         "bootstrap.servers": os.environ["PRODUCER_SERVER"],
         "acks": "all",
+        "security.protocol": "SASL_SSL",
+        "sasl.mechanism": "SCRAM-SHA-512",
+        "sasl.username": os.environ["PRODUCER_USERNAME"],
+        "sasl.password": os.environ["PRODUCER_PASSWORD"],
     },
 }
 
@@ -54,6 +58,10 @@ METRICS_CONFIG = {
     "PARAMS": {
         "PARAMS": {
             "bootstrap.servers": os.environ["METRICS_HOST"],
+            "security.protocol": "SASL_SSL",
+            "sasl.mechanism": "SCRAM-SHA-512",
+            "sasl.username": os.environ["METRICS_USERNAME"],
+            "sasl.password": os.environ["METRICS_PASSWORD"],
         },
         "TOPIC": os.environ["METRICS_TOPIC"],
         "SCHEMA": {
@@ -92,18 +100,10 @@ METRICS_CONFIG = {
     },
 }
 
-STEP_METADATA = {
-    "STEP_VERSION": os.getenv("STEP_VERSION", "dev"),
-    "STEP_ID": os.getenv("STEP_ID", "reflector_step"),
-    "STEP_NAME": os.getenv("STEP_NAME", "reflector_step"),
-    "STEP_COMMENTS": os.getenv("STEP_COMMENTS", ""),
-}
-
 # Step Configuration
 STEP_CONFIG = {
     "CONSUMER_CONFIG": CONSUMER_CONFIG,
     "PRODUCER_CONFIG": PRODUCER_CONFIG,
     "METRICS_CONFIG": METRICS_CONFIG,
-    "N_PROCESS": os.getenv("N_PROCESS"),
-    "STEP_METADATA": STEP_METADATA,
+    "keep_original_timestamp": os.getenv("KEEP_ORIGINAL_TIMESTAMP", False),
 }

--- a/sorting_hat_step/sorting_hat_step/step.py
+++ b/sorting_hat_step/sorting_hat_step/step.py
@@ -56,9 +56,16 @@ class SortingHatStep(GenericStep):
         self.metrics["aid"] = alerts["aid"].tolist()
 
     def pre_execute(self, messages: List[dict]):
-        ingestion_timestamp = datetime.now().timestamp()
+        ingestion_timestamp = int(datetime.now().timestamp())
         messages_with_timestamp = list(
-            map(lambda m: {**m, "brokerIngestTimestamp": ingestion_timestamp}, messages)
+            map(
+                lambda m: {
+                    **m,
+                    "brokerIngestTimestamp": ingestion_timestamp,
+                    "surveyPublishTimestamp": m["timestamp"],
+                },
+                messages,
+            )
         )
         return messages_with_timestamp
 

--- a/sorting_hat_step/tests/integration/test_run_step.py
+++ b/sorting_hat_step/tests/integration/test_run_step.py
@@ -128,8 +128,8 @@ class MongoIntegrationTest(unittest.TestCase):
         messages = self.consume_messages()
         assert len(messages) == 110
         for message in messages:
-            # TODO add other assertions
             self.assert_message_stamps(message)
+            self.assert_message_timestamps(message)
 
         # Check that there are no duplicates inserted
         cursor = self.database.database["object"].find()
@@ -162,6 +162,14 @@ class MongoIntegrationTest(unittest.TestCase):
         if message["tid"] == "ATLAS":
             assert message["stamps"]["template"] == None
         assert message["stamps"]["difference"] == b"difference"
+
+    def assert_message_timestamps(self, message: dict):
+        assert message.get("extra_fields").get("brokerIngestTimestamp") is not None
+        assert message.get("extra_fields").get("surveyPublishTimestamp") is not None
+        assert (
+            message["extra_fields"]["surveyPublishTimestamp"]
+            <= message["extra_fields"]["brokerIngestTimestamp"]
+        )
 
     def test_write_object(self):
         step = SortingHatStep(

--- a/sorting_hat_step/tests/unittest/data/batch.py
+++ b/sorting_hat_step/tests/unittest/data/batch.py
@@ -2,6 +2,7 @@ import random
 import string
 import pandas as pd
 from typing import List
+from datetime import datetime
 
 random.seed(1313)
 
@@ -294,6 +295,10 @@ def generate_alerts_batch(n: int, nearest: int = 0) -> List[dict]:
     batch = []
     for generator, m, near in zip(generators, sub_samples, sub_nearest):
         b = generator(m, nearest=near)
+        b = list(
+            map(lambda el: {**el, "timestamp": int(datetime.now().timestamp())}, b)
+        )
+        print("BBBBBBB", b[0]["timestamp"])
         batch.append(b)
     batch = sum(batch, [])
     return batch


### PR DESCRIPTION
ELaSTiCC
- Added surveyPublishTimestamp that is sent as elasticcPublishTimestamp by lc_classification_step
- Fixed brokerIngestionTimestamp not being milliseconds

Reflector step:
- Added an option to keep the original timestamp from the source topic
  This could be used for elasticc, making the "timestamp" value added by APF the same as the timestamp from the source elasticc topic on ZTF Kafka Broker