### PR TITLE
feat: enrich metrics with metadata

### DIFF
--- a/.github/workflows/apf.yaml
+++ b/.github/workflows/apf.yaml
@@ -203,6 +203,7 @@ jobs:
       TEST_TORETTO_MODEL_PATH: "${{ secrets.TEST_TORETTO_MODEL_PATH }}"
       TEST_BARNEY_MODEL_PATH: "${{ secrets.TEST_BARNEY_MODEL_PATH }}"
       TEST_NEW_BARNEY_MODEL_PATH: "${{ secrets.TEST_NEW_BARNEY_MODEL_PATH }}"
+      TEST_MLP_MODEL_PATH: "${{ secrets.TEST_MLP_MODEL_PATH }}"
   lc_classification_step_integration:
     uses: ./.github/workflows/poetry-tests-template.yaml
     with:
@@ -221,6 +222,7 @@ jobs:
       TEST_TORETTO_MODEL_PATH: "${{ secrets.TEST_TORETTO_MODEL_PATH }}"
       TEST_BARNEY_MODEL_PATH: "${{ secrets.TEST_BARNEY_MODEL_PATH }}"
       TEST_NEW_BARNEY_MODEL_PATH: "${{ secrets.TEST_NEW_BARNEY_MODEL_PATH }}"
+      TEST_MLP_MODEL_PATH: "${{ secrets.TEST_MLP_MODEL_PATH }}"
 
   lc_classification_step_build_ztf:
     uses: ./.github/workflows/build-template.yaml

--- a/.github/workflows/poetry-tests-template.yaml
+++ b/.github/workflows/poetry-tests-template.yaml
@@ -55,6 +55,9 @@ on:
       TEST_BARNEY_MODEL_PATH:
         required: false
         description: 'A path to a .pkl file'
+      TEST_NEW_BARNEY_MODEL_PATH:
+        required: false
+        description: 'A path to a .pkl file'
       TEST_MLP_MODEL_PATH:
         required: false
         description: 'A path to a .pkl file'

--- a/.github/workflows/poetry-tests-template.yaml
+++ b/.github/workflows/poetry-tests-template.yaml
@@ -70,6 +70,7 @@ jobs:
       TEST_MESSI_FEATURE_QUANTILES_PATH: ${{ secrets.TEST_MESSI_FEATURE_QUANTILES_PATH }}
       TEST_TORETTO_MODEL_PATH: ${{ secrets.TEST_TORETTO_MODEL_PATH }}
       TEST_BARNEY_MODEL_PATH: ${{ secrets.TEST_BARNEY_MODEL_PATH }}
+      TEST_NEW_BARNEY_MODEL_PATH: ${{ secrets.TEST_NEW_BARNEY_MODEL_PATH }}
       TEST_MLP_MODEL_PATH: ${{ secrets.TEST_MLP_MODEL_PATH }}
     steps:
       - name: Check out repository code

--- a/correction_step/correction/_step/step.py
+++ b/correction_step/correction/_step/step.py
@@ -42,36 +42,25 @@ class CorrectionStep(GenericStep):
         logger = logging.getLogger("alerce")
         logger.setLevel(level)
 
-        fmt = logging.Formatter(
-            "%(asctime)s %(levelname)7s %(name)36s: %(message)s", "%Y-%m-%d %H:%M:%S"
-        )
+        fmt = logging.Formatter("%(asctime)s %(levelname)7s %(name)36s: %(message)s", "%Y-%m-%d %H:%M:%S")
         handler = logging.StreamHandler()
         handler.setFormatter(fmt)
         handler.setLevel(level)
 
         logger.addHandler(handler)
 
-        prefix = os.getenv("CLASS_PREFIX", "")
-        prometheus_metrics = (
-            PrometheusMetrics()
-            if settings["PROMETHEUS"]
-            else DefaultPrometheusMetrics()
-        )
+        prometheus_metrics = PrometheusMetrics() if settings["PROMETHEUS"] else DefaultPrometheusMetrics()
         if settings["PROMETHEUS"]:
             start_http_server(8000)
 
-        return CorrectionStep(
-            config=settings, prometheus_metrics=prometheus_metrics, prefix=prefix
-        )
+        return CorrectionStep(config=settings, prometheus_metrics=prometheus_metrics)
 
     @classmethod
     def pre_produce(cls, result: dict):
         detections = pd.DataFrame(result["detections"]).groupby("aid")
         try:  # At least one non-detection
             non_detections = pd.DataFrame(result["non_detections"]).groupby("aid")
-        except (
-            KeyError
-        ):  # to reproduce expected error for missing non-detections in loop
+        except KeyError:  # to reproduce expected error for missing non-detections in loop
             non_detections = pd.DataFrame(columns=["aid"]).groupby("aid")
         output = []
         for aid, dets in detections:
@@ -102,9 +91,7 @@ class CorrectionStep(GenericStep):
     def execute(cls, message: dict) -> dict:
         corrector = Corrector(message["detections"])
         detections = corrector.corrected_as_records()
-        non_detections = pd.DataFrame(message["non_detections"]).drop_duplicates(
-            ["oid", "fid", "mjd"]
-        )
+        non_detections = pd.DataFrame(message["non_detections"]).drop_duplicates(["oid", "fid", "mjd"])
         coords = corrector.coordinates_as_records()
         return {
             "detections": detections,

--- a/feature_step/features/core/elasticc.py
+++ b/feature_step/features/core/elasticc.py
@@ -61,7 +61,9 @@ class ELAsTiCCFeatureExtractor:
     def _create_metadata_dataframe(self, detections: pd.DataFrame):
         # Keep one metadata row per object, as it should not change
         # between detections for a given object
-        one_detection_per_object = detections[["extra_fields"]][~detections.index.duplicated(keep="first")]
+        one_detection_per_object = detections[["extra_fields"]][
+            ~detections.index.duplicated(keep="first")
+        ]
         metadata = []
         for ef in one_detection_per_object["extra_fields"]:
             metadata.append(pickle.loads(ef["diaObject"])[0])

--- a/feature_step/scripts/run_step.py
+++ b/feature_step/scripts/run_step.py
@@ -35,8 +35,7 @@ if STEP_CONFIG["USE_PROFILING"]:
         server_address=STEP_CONFIG["PYROSCOPE_SERVER"],
     )
 
-prefix = os.getenv("CLASS_PREFIX", "")
 
 extractor = selector(EXTRACTOR)
-step = FeaturesComputer(extractor, config=STEP_CONFIG, prefix=prefix)
+step = FeaturesComputer(extractor, config=STEP_CONFIG)
 step.start()

--- a/libs/apf/apf/core/step.py
+++ b/libs/apf/apf/core/step.py
@@ -330,7 +330,8 @@ class GenericStep(abc.ABC):
 
             val = message.get(params["key"])
             if val is None or "value" in params:
-                val = params["value"]
+                # returns None, so val will remain None or take the value of params["value"]
+                val = params.get("value")
 
             if "format" in params:
                 if not callable(params["format"]):

--- a/libs/apf/apf/core/step.py
+++ b/libs/apf/apf/core/step.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 from abc import abstractmethod
 from typing import Any, Dict, Iterable, List, Type, Union
+import os
 
 from apf.consumers import GenericConsumer
 from apf.core import get_class
@@ -56,7 +57,6 @@ class GenericStep(abc.ABC):
         level: int = logging.NOTSET,
         config: dict = {},
         prometheus_metrics: PrometheusMetrics = DefaultPrometheusMetrics(),
-        prefix: str = ""
     ):
         self._set_logger(level)
         self.config = config
@@ -66,7 +66,6 @@ class GenericStep(abc.ABC):
             self.metrics_producer_params
         )
         self.metrics = {}
-        self.prefix = prefix
         self.extra_metrics = []
         if self.metrics_config:
             self.extra_metrics = self.metrics_config.get("EXTRA_METRICS", ["candid"])
@@ -161,7 +160,6 @@ class GenericStep(abc.ABC):
 
         """
         if self.metrics_sender:
-            metrics["source"] = f"{self.prefix}{self.__class__.__name__}"
             self.metrics_sender.send_metrics(metrics)
 
     def _pre_consume(self):
@@ -184,16 +182,8 @@ class GenericStep(abc.ABC):
         self.message = message
         if isinstance(self.message, dict):
             self.prometheus_metrics.consumed_messages.observe(1)
-            # tid = self.message.get("tid")
-            # if tid:
-            #     tid = str(tid).upper()
-            #     self.prometheus_metrics.telescope_id.state(tid)
         if isinstance(self.message, list):
             self.prometheus_metrics.consumed_messages.observe(len(self.message))
-            # tid = self.message[0].get("tid")
-            # if tid:
-            #     tid = str(tid).upper()
-            #     self.prometheus_metrics.telescope_id.state(tid)
         try:
             preprocessed = self.pre_execute(self.message)
         except Exception as error:
@@ -242,6 +232,12 @@ class GenericStep(abc.ABC):
         if self.extra_metrics:
             extra_metrics = self.get_extra_metrics(self.message)
             self.metrics.update(extra_metrics)
+        if "source" not in self.metrics:
+            self.metrics["source"] = os.getenv(
+                "METRICS_SOURCE", f"{self.__class__.__name__}"
+            )
+        if "survey" not in self.metrics:
+            self.metrics["survey"] = os.getenv("METRICS_SURVEY")
         self.send_metrics(**self.metrics)
         if isinstance(self.message, dict):
             self.prometheus_metrics.processed_messages.observe(1)
@@ -333,6 +329,9 @@ class GenericStep(abc.ABC):
                 raise KeyError("'key' in parameteres not found")
 
             val = message.get(params["key"])
+            if val is None or "value" in params:
+                val = params["value"]
+
             if "format" in params:
                 if not callable(params["format"]):
                     raise ValueError("'format' parameter must be a calleable.")

--- a/lightcurve-step/lightcurve_step/step.py
+++ b/lightcurve-step/lightcurve_step/step.py
@@ -95,7 +95,7 @@ class LightcurveStep(GenericStep):
         return {
             "detections": detections,
             "non_detections": non_detections,
-            "last_mjds": messages["last_mjds"]
+            "last_mjds": messages["last_mjds"],
         }
 
     @classmethod

--- a/lightcurve-step/scripts/run_step.py
+++ b/lightcurve-step/scripts/run_step.py
@@ -32,7 +32,6 @@ def step_creator():
     step_params = {
         "config": settings,
         "db_client": db,
-        "prefix": os.getenv("CLASS_PREFIX", "")
     }
 
     if settings["PROMETHEUS"]:

--- a/prv_candidates_step/scripts/run_step.py
+++ b/prv_candidates_step/scripts/run_step.py
@@ -39,12 +39,9 @@ def step_creator():
     if settings["USE_PROMETHEUS"]:
         start_http_server(8000)
 
-    prefix = os.getenv("CLASS_PREFIX", "")
-
     return PrvCandidatesStep(
         config=settings,
         prometheus_metrics=prometheus_metrics,
-        prefix=prefix,
     )
 
 

--- a/sorting_hat_step/scripts/run_step.py
+++ b/sorting_hat_step/scripts/run_step.py
@@ -44,12 +44,10 @@ if bool(os.getenv("USE_PROFILING", True)):
 
 prometheus_metrics = PrometheusMetrics()
 start_http_server(8000)
-prefix = os.getenv("CLASS_PREFIX", "")
 
 step = SortingHatStep(
     db_connection=database,
     config=STEP_CONFIG,
     prometheus_metrics=prometheus_metrics,
-    prefix=prefix
 )
 step.start()


### PR DESCRIPTION
## Summary of the changes

For monitoring purposes, additional information on the metrics that the step produces is needed.

Previous to this change, linking kubernetes metadata such as the deployment or chart name with the metrics `source` field, for example, was not possible.

Now, the source field can come from an environment variable, that should match the kubernetes metadata.

Logs captured from the running steps are labeled with Kubernetes metadata. So now, when we need to relate the `source` field with a deployment on EKS, we only need to verify that the correct environment variable is set (see https://github.com/alercebroker/kubernetes_pipeline/commit/caea7b3d4abe86476a0f7b5558778bfb9d0a57c9).

Also added a `survey` field so that we can later filter metrics from ELASTICC.

## Observations

It is important that the kubernetes labels, in particular `app.kubernetes.io/instance`, matches the source field. This is achieved by setting the env variable value to `{{ .Release.Name }}` on the chart, so that it is templated to the same value as the label.


## If the change is BREAKING, please give more details about the breaking changes

It breaks the previous `CLASS_PREFIX` approach, that only changed the `source` field with a prefix instead of allowing to modifying it completely.

#### Components that need updates and steps to follow

Every step should be redeployed with the updated chart versions.


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->