### PR TITLE
Adding magstats calculation for only ZTF detections

### DIFF
--- a/magstats_step/.gitignore
+++ b/magstats_step/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 .idea
 __SUCCESS__
+.vscode/

--- a/magstats_step/magstats_step/core/_base.py
+++ b/magstats_step/magstats_step/core/_base.py
@@ -13,7 +13,7 @@ class BaseStatistics(abc.ABC):
     _CORRECTED = ("ZTF",)
     _STELLAR = ("ZTF",)
 
-    def __init__(self, detections: List[dict]):
+    def __init__(self, detections: List[dict], filter: Union[str, None]=None):
         try:
             self._detections = pd.DataFrame.from_records(detections, exclude=["extra_fields"])
         except KeyError:  # extra_fields is not present
@@ -21,6 +21,8 @@ class BaseStatistics(abc.ABC):
         self._detections = self._detections.drop_duplicates("candid").set_index("candid")
         # Select only non-forced detections
         self._detections = self._detections[~self._detections["forced"]]
+        if filter:
+            self._detections = self._detections[self._detections["sid"] == filter]
 
     @classmethod
     def _group(cls, df: Union[pd.DataFrame, pd.Series]) -> Union[DataFrameGroupBy, SeriesGroupBy]:

--- a/magstats_step/magstats_step/core/objstats.py
+++ b/magstats_step/magstats_step/core/objstats.py
@@ -9,8 +9,10 @@ from ._base import BaseStatistics
 class ObjectStatistics(BaseStatistics):
     _JOIN = "aid"
 
-    def __init__(self, detections: List[dict]):
-        super().__init__(detections)
+    def __init__(self, detections: List[dict], filter: Union[str, None]=None):
+        super().__init__(detections, filter=filter)
+        if filter == "ZTF":
+            self._JOIN = "oid"
 
     @staticmethod
     def _arcsec2deg(values: Union[pd.Series, float]) -> Union[pd.Series, float]:

--- a/magstats_step/tests/unittests/data/messages.py
+++ b/magstats_step/tests/unittests/data/messages.py
@@ -6,19 +6,27 @@ from fastavro import utils
 SCHEMA = schema.load_schema("schema.avsc")
 random.seed(42)
 
-aids_pool = [f"AID22X{i}" for i in range(10)]
+aids_pool = [f"AID22X{i}" for i in range(50)]
+oids_pool = [f"ZTF{i}llmn" for i in range(100)]
 
 data = list(utils.generate_many(SCHEMA, 10))
 for d in data:
     aid = random.choice(aids_pool)
     d["aid"] = aid
+    oid = random.choice(oids_pool)
     sid = "ZTF" if random.random() < 0.5 else "ATLAS"
     for detection in d["detections"]:
         detection["aid"] = aid
         detection["sid"] = sid
         detection["fid"] = "g" if random.random() < 0.5 else "r"
         detection["forced"] = False
+        detection["oid"] = oid
+        
+    if sid != "ZTF":
+        d["non_detections"] = []
+        continue
     for non_detection in d["non_detections"]:
         non_detection["aid"] = aid
         non_detection["sid"] = sid
+        non_detection["oid"] = oid
         non_detection["fid"] = "g" if random.random() < 0.5 else "r"


### PR DESCRIPTION
## Summary of the changes

Creating a parallel calculation only considering the ZTF detections, so ALeRCE still supports ZTF as a standalone survey. 


## Observations

The idea is to prevent other surveys to pollute the calculation of ZTF objects. This ZTF-only stats are to be stored in the PSQL database.


## If the change is BREAKING, please give more details about the breaking changes

27-09-2023: It would not break Scribe as the multistream message will remain the same

#### Components that need updates and steps to follow

<-- Link repos or other PRs !-->


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->