### PR TITLE
Fix bug in conesearch

### DIFF
--- a/sorting_hat_step/sorting_hat_step/utils/database.py
+++ b/sorting_hat_step/sorting_hat_step/utils/database.py
@@ -41,7 +41,7 @@ def conesearch_query(
                         "type": "Point",
                         "coordinates": [ra - 180, dec],
                     },
-                    "$maxDistance": math.radians(radius / 3600),
+                    "$maxDistance": math.radians(radius / 3600) * 6.3781e6,
                 },
             },
         },

--- a/sorting_hat_step/tests/unittest/test_database.py
+++ b/sorting_hat_step/tests/unittest/test_database.py
@@ -44,7 +44,7 @@ class DatabaseTestCase(unittest.TestCase):
                 "loc": {
                     "$nearSphere": {
                         "$geometry": {"type": "Point", "coordinates": [0, 0]},
-                        "$maxDistance": 1,
+                        "$maxDistance": 6.3781e6,
                     },
                 },
             },


### PR DESCRIPTION
## Summary of the changes

I corrected the search radius units received by the cone search query to DB, from radians to meters. Bug was described in https://github.com/alercebroker/pipeline/issues/165.


## Observations

The fix uses the Earth radius in meters. The value is taken from https://www.mongodb.com/docs/manual/core/indexes/index-types/geospatial/2d/calculate-distances/.


## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.