### PR TITLE
refactor: added filter to remove forced photometry detections

### DIFF
--- a/feature_step/features/core/handlers/detections.py
+++ b/feature_step/features/core/handlers/detections.py
@@ -29,7 +29,13 @@ class DetectionsHandler(BaseHandler):
     _NAME = "detections"
     INDEX = "candid"
     UNIQUE = ["id", "fid", "mjd"]
-    COLUMNS = BaseHandler.COLUMNS + ["mag", "e_mag", "mag_ml", "e_mag_ml"]
+    COLUMNS = BaseHandler.COLUMNS + [
+        "mag",
+        "e_mag",
+        "mag_ml",
+        "e_mag_ml",
+        "forced",
+    ]
 
     def _post_process(self, **kwargs):
         """Handles legacy alerts (renames old field names to the new conventions) and sets the

--- a/feature_step/features/core/ztf.py
+++ b/feature_step/features/core/ztf.py
@@ -57,6 +57,7 @@ class ZTFFeatureExtractor(BaseFeatureExtractor):
                 detections, non_detections, xmatches, metadata
             )
 
+        detections = list(filter(lambda d: not d.get("forced", False), detections))
         super().__init__(detections, non_detections, xmatches)
 
         # Change isdiffpos from 1 or -1 to True or False
@@ -134,9 +135,7 @@ class ZTFFeatureExtractor(BaseFeatureExtractor):
     @decorators.logger
     @decorators.add_fid("gr")
     def calculate_colors(self) -> pd.DataFrame:
-        gr_max = self.detections.get_colors(
-            "min", ("g", "r"), ml=False, flux=self.FLUX
-        )
+        gr_max = self.detections.get_colors("min", ("g", "r"), ml=False, flux=self.FLUX)
         gr_max_corr = self.detections.get_colors(
             "min", ("g", "r"), ml=True, flux=self.FLUX
         )
@@ -183,9 +182,7 @@ class ZTFFeatureExtractor(BaseFeatureExtractor):
     @decorators.logger
     @decorators.add_fid("")
     def calculate_sg_score(self) -> pd.DataFrame:
-        return pd.DataFrame(
-            {"sgscore1": self.detections.agg("sgscore1", "median")}
-        )
+        return pd.DataFrame({"sgscore1": self.detections.agg("sgscore1", "median")})
 
     @decorators.logger
     @decorators.columns_per_fid
@@ -221,9 +218,7 @@ class ZTFFeatureExtractor(BaseFeatureExtractor):
         delta_mag = self.detections.get_delta("mag_ml", by_fid=True)
         min_mag = self.detections.agg("mag_ml", "min", by_fid=True)
         mean_mag = self.detections.agg("mag_ml", "mean", by_fid=True)
-        first_mag = self.detections.which_value(
-            "mag_ml", which="first", by_fid=True
-        )
+        first_mag = self.detections.which_value("mag_ml", which="first", by_fid=True)
 
         max_upper_before = self.non_detections.agg_when(
             "diffmaglim", "max", when="before", by_fid=True

--- a/feature_step/features/core/ztf.py
+++ b/feature_step/features/core/ztf.py
@@ -57,7 +57,9 @@ class ZTFFeatureExtractor(BaseFeatureExtractor):
                 detections, non_detections, xmatches, metadata
             )
 
-        detections = list(filter(lambda d: not d.get("forced", False), detections))
+        detections = list(
+            filter(lambda d: not d.get("forced", False), detections)
+        )
         super().__init__(detections, non_detections, xmatches)
 
         # Change isdiffpos from 1 or -1 to True or False
@@ -135,7 +137,9 @@ class ZTFFeatureExtractor(BaseFeatureExtractor):
     @decorators.logger
     @decorators.add_fid("gr")
     def calculate_colors(self) -> pd.DataFrame:
-        gr_max = self.detections.get_colors("min", ("g", "r"), ml=False, flux=self.FLUX)
+        gr_max = self.detections.get_colors(
+            "min", ("g", "r"), ml=False, flux=self.FLUX
+        )
         gr_max_corr = self.detections.get_colors(
             "min", ("g", "r"), ml=True, flux=self.FLUX
         )
@@ -182,7 +186,9 @@ class ZTFFeatureExtractor(BaseFeatureExtractor):
     @decorators.logger
     @decorators.add_fid("")
     def calculate_sg_score(self) -> pd.DataFrame:
-        return pd.DataFrame({"sgscore1": self.detections.agg("sgscore1", "median")})
+        return pd.DataFrame(
+            {"sgscore1": self.detections.agg("sgscore1", "median")}
+        )
 
     @decorators.logger
     @decorators.columns_per_fid
@@ -218,7 +224,9 @@ class ZTFFeatureExtractor(BaseFeatureExtractor):
         delta_mag = self.detections.get_delta("mag_ml", by_fid=True)
         min_mag = self.detections.agg("mag_ml", "min", by_fid=True)
         mean_mag = self.detections.agg("mag_ml", "mean", by_fid=True)
-        first_mag = self.detections.which_value("mag_ml", which="first", by_fid=True)
+        first_mag = self.detections.which_value(
+            "mag_ml", which="first", by_fid=True
+        )
 
         max_upper_before = self.non_detections.agg_when(
             "diffmaglim", "max", when="before", by_fid=True

--- a/feature_step/tests/data/elasticc_message_factory.py
+++ b/feature_step/tests/data/elasticc_message_factory.py
@@ -33,6 +33,7 @@ def generate_alert(
     aid: str, band: str, num_messages: int, identifier: int, **kwargs
 ) -> list[dict]:
     alerts = []
+    survey_id = kwargs.get("survey", "LSST")
     diaObject = get_extra_fields()["diaObject"]
     for i in range(num_messages):
         extra_fields = get_extra_fields()
@@ -41,9 +42,9 @@ def generate_alert(
             "candid": str(random.randint(1000000, 9000000)),
             "oid": f"oid{identifier}",
             "aid": aid,
-            "tid": "LSST",
+            "tid": survey_id,
             "mjd": random.uniform(59000, 60000),
-            "sid": "LSST",
+            "sid": survey_id,
             "fid": band,
             "pid": random.randint(1000000, 9000000),
             "ra": random.uniform(-90, 90),
@@ -91,7 +92,7 @@ def generate_non_det(aid: str, num: int, identifier: int) -> list[dict]:
     return non_det
 
 
-def generate_input_batch(n: int, bands: list[str], offset=0) -> list[dict]:
+def generate_input_batch(n: int, bands: list[str], offset=0, survey = "LSST") -> list[dict]:
     """
     Parameters
     ----------
@@ -107,7 +108,7 @@ def generate_input_batch(n: int, bands: list[str], offset=0) -> list[dict]:
         detections = []
         for band in bands:
             detections.extend(
-                generate_alert(aid, band, random.randint(6, 10), m)
+                generate_alert(aid, band, random.randint(6, 10), m, survey=survey)
             )
         non_det = generate_non_det(aid, random.randint(0, 1), m)
         xmatch = {}

--- a/feature_step/tests/unittest/test_ztf_extractor.py
+++ b/feature_step/tests/unittest/test_ztf_extractor.py
@@ -1,0 +1,18 @@
+import unittest
+from features.core.ztf import ZTFFeatureExtractor
+from tests.data.elasticc_message_factory import generate_input_batch
+
+
+class TestZTFExtractor(unittest.TestCase):
+    # this test includes an assertion of the exclusion of fp
+    # remove when necesary
+    def test_init(self):
+        detections = []
+        input_batch = generate_input_batch(10, ["g", "r"], survey="ZTF")
+        for msg in input_batch:
+            detections.extend(msg.get("detections", []))
+
+        extractor = ZTFFeatureExtractor(
+            detections=detections, non_detections=[], xmatch=[]
+        )
+        self.assertTrue(not extractor.detections._alerts["forced"].any())


### PR DESCRIPTION
## Summary of the changes

Added a patch that filters the forced photometry detections. 
If a detection doesn't have the flag, it's considered not forced.


## Observations

<-- Add some notes to keep in mind !-->


## About this PR:

- [X] You added the necessary documentation for the team to understand your work.
- [X] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [X] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.
