### PR TITLE
fix: update import and db_config handling

### DIFF
--- a/libs/db-plugins/db_plugins/db/sql/migrations/env.py
+++ b/libs/db-plugins/db_plugins/db/sql/migrations/env.py
@@ -1,4 +1,4 @@
-from db_plugins.db.sql.connection import Base, satisfy_keys, settings_map
+from db_plugins.db.sql._connection import Base, get_db_url
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
@@ -13,9 +13,7 @@ from settings import DB_CONFIG
 config = context.config
 if "SQL" in DB_CONFIG:
     db_config = DB_CONFIG["SQL"]
-    required_key = satisfy_keys(set(db_config.keys()))
-    if len(required_key) == 0:
-        db_config["SQLALCHEMY_DATABASE_URL"] = settings_map(db_config)
+    db_config["SQLALCHEMY_DATABASE_URL"] = get_db_url(db_config)
 else:
     raise Exception(f"Missing arguments in settings")
 


### PR DESCRIPTION
## Summary of the changes

- Fix for the CLI command `initdb`. The import was wrong and also the credentials handling was refactored a while ago without including the initialization script.

This PR addresses that situation.


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.