### PR TITLE
feat: now sorting hat adds to the psql the received object (if not pr…

### DIFF
--- a/sorting_hat_step/sorting_hat_step/database.py
+++ b/sorting_hat_step/sorting_hat_step/database.py
@@ -1,4 +1,9 @@
+from contextlib import contextmanager
+from typing import Callable, ContextManager, Dict
+
 from pymongo import MongoClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
 
 
 class DatabaseConnection:
@@ -7,3 +12,24 @@ class DatabaseConnection:
         _database = self.config.pop("database")
         self.client = MongoClient(**self.config)
         self.database = self.client[_database]
+
+
+class PSQLConnection:
+    def __init__(self, config: Dict) -> None:
+        url = self.__format_db_url(config)
+        self._engine = create_engine(url)
+        self._session_factory = sessionmaker(self._engine)
+
+    def __format_db_url(self, config: Dict):
+        return f"postgresql://{config['USER']}:{config['PASSWORD']}@{config['HOST']}:{config['PORT']}/{config['DB_NAME']}"
+
+    @contextmanager
+    def session(self) -> Callable[[], ContextManager[Session]]:
+        session: Session = self._session_factory()
+        try:
+            yield session
+        except Exception as e:
+            session.rollback()
+            raise
+        finally:
+            session.close()

--- a/sorting_hat_step/sorting_hat_step/utils/database.py
+++ b/sorting_hat_step/sorting_hat_step/utils/database.py
@@ -1,7 +1,10 @@
 import math
-from typing import Union, List
+from typing import Dict, Union, List
 
-from ..database import DatabaseConnection
+from sqlalchemy.dialects.postgresql import insert
+
+from db_plugins.db.sql.models import Object
+from ..database import DatabaseConnection, PSQLConnection
 
 
 def oid_query(db: DatabaseConnection, oid: list) -> Union[str, None]:
@@ -68,3 +71,13 @@ def update_query(db: DatabaseConnection, records: List[dict]):
         db.database["object"].find_one_and_update(
             query, new_value, upsert=True, return_document=True
         )
+
+
+def insert_empty_objects_to_sql(db: PSQLConnection, records: List[Dict]):
+    # insert into db values = records on conflict do nothing
+
+    with db.session() as session:
+        insert(Object).values(
+            [{"oid": r["oid"]} for r in records]
+        ).on_conflict_do_nothing()
+        session.commit()

--- a/sorting_hat_step/sorting_hat_step/utils/wizard.py
+++ b/sorting_hat_step/sorting_hat_step/utils/wizard.py
@@ -6,8 +6,13 @@ import numpy as np
 import pandas as pd
 from scipy.spatial import cKDTree
 
-from .database import oid_query, conesearch_query, update_query
-from ..database import DatabaseConnection
+from .database import (
+    oid_query,
+    conesearch_query,
+    update_query,
+    insert_empty_objects_to_sql,
+)
+from ..database import DatabaseConnection, PSQLConnection
 
 
 CHARACTERS = string.ascii_lowercase
@@ -230,7 +235,7 @@ def generate_new_id(alerts: pd.DataFrame):
     return alerts
 
 
-def insert_empty_objects(db: DatabaseConnection, alerts: pd.DataFrame):
+def insert_empty_objects(mongodb: DatabaseConnection, psql: PSQLConnection, alerts: pd.DataFrame):
     """
     Inserts an empty entry to the database for every unique _id in the
     alerts dataframe
@@ -244,4 +249,5 @@ def insert_empty_objects(db: DatabaseConnection, alerts: pd.DataFrame):
     logger.debug(
         f"Inserting or updating {len(objects)} entries into the Objects collection"
     )
-    update_query(db, objects.to_dict("records"))
+    update_query(mongodb, objects.to_dict("records"))
+    insert_empty_objects_to_sql(psql, objects.to_dict("records"))


### PR DESCRIPTION
…eviously inserted)

## Summary of the changes

This change allows Sorting Hat to insert an OID into the SQL database, so Scribe can work with the OID as a Foreign Key.
If the object was inserted previously, Sorting Hat won't do anything.


## Observations

Notice that the Sorting Hat has not a PSQL connection set. 


## If the change is BREAKING, please give more details about the breaking changes

A PSQL config is needed in order to work. Please check if the deployment of Sorting Hat provides the env variables needed.


## About this PR:

- [X] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.
