### PR TITLE
feat: add usePsql feature flag

### DIFF
--- a/charts/sorting_hat_step/templates/configmap.yaml
+++ b/charts/sorting_hat_step/templates/configmap.yaml
@@ -19,5 +19,16 @@ data:
   metrics-server: {{ .Values.configmap.metricsServer }}
   metrics-topic: {{ .Values.configmap.metricsTopic }}
   mongo-secret-name: {{ .Values.configmap.mongoSecretName }}
-  run-conesearch: '{{ .Values.configmap.runConesearch }}'
-  use-profiling: '{{ .Values.configmap.useProfiling }}'
+  {{- if .Values.featureFlags.usePsql }}
+  psql-secret-name: {{ .Values.configmap.psqlSecretName }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: 'feature-flags'
+  namespace: {{ .Values.namespace }}
+data:
+  run-conesearch: '{{ .Values.featureFlags.runConesearch }}'
+  use-profiling: '{{ .Values.featureFlags.useProfiling }}'
+  use-psql: '{{ .Values.featureFlags.usePsql }}'

--- a/charts/sorting_hat_step/templates/deployment.yaml
+++ b/charts/sorting_hat_step/templates/deployment.yaml
@@ -114,13 +114,18 @@ spec:
             - name: RUN_CONESEARCH
               valueFrom:
                 configMapKeyRef:
-                  name: '{{ include "sorting-hat.fullname" . }}'
+                  name: 'feature-flags'
                   key: run-conesearch
             - name: USE_PROFILING
               valueFrom:
                 configMapKeyRef:
-                  name: '{{ include "sorting-hat.fullname" . }}'
+                  name: 'feature-flags'
                   key: use-profiling
+            - name: USE_PSQL
+              valueFrom:
+                configMapKeyRef:
+                  name: 'feature-flags'
+                  key: use-psql
             - name: PYROSCOPE_SERVER
               valueFrom:
                 configMapKeyRef:

--- a/charts/sorting_hat_step/templates/deployment.yaml
+++ b/charts/sorting_hat_step/templates/deployment.yaml
@@ -101,6 +101,13 @@ spec:
                 configMapKeyRef:
                   name: '{{ include "sorting-hat.fullname" . }}'
                   key: mongo-secret-name
+            {{- if .Values.featureFlags.usePsql }}
+            - name: PSQL_SECRET_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: '{{ include "sorting-hat.fullname" . }}'
+                  key: psql-secret-name
+            {{- end }}
             - name: METRICS_HOST
               valueFrom:
                 configMapKeyRef:

--- a/charts/sorting_hat_step/values.yaml
+++ b/charts/sorting_hat_step/values.yaml
@@ -62,10 +62,13 @@ configmap:
   metricsTopic: ""
   metricsServer: ""
   mongoSecretName: ""
+  psqlSecretName: ""
+  pyroscopeServer: "http://pyroscope.pyroscope:4040"
+
+featureFlags:
   runConesearch: ""
   useProfiling: ""
-  classPrefix: ""
-  pyroscopeServer: "http://pyroscope.pyroscope:4040"
+  usePsql: "False"
 
 secrets:
   kafkaAuth:


### PR DESCRIPTION
-------

## Summary of the changes

Updates the sorting hat chart so that it reflects the changes in the code.

In particular, the step added a flag for PSQL and the PSQL credentials environment variables so the chart now supports that.


## Observations
The values changes are the following:

- `configmap.psqlSecretName` is a new value
- `configmop.runConesearch` and `configmap.useProfiling` are now on a different key `featureFlags.runConesearch` and `featureFlags.useProfiling`
- `featureFlags.usePsql` is False by default


## If the change is BREAKING, please give more details about the breaking changes
The configmap value keys have changed and now there is a separate configmap resource for feature flags.
The changes are described in the Observations section.


#### Components that need updates and steps to follow

- Update SSM Parameter Store for the sorting hat step deployment for ZTF and ATLAS

## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.