### PR TITLE
Fix bug in cos(Dec) for LSST parser

### DIFF
--- a/libs/survey_parser_plugins/survey_parser_plugins/parsers/LSSTParser.py
+++ b/libs/survey_parser_plugins/survey_parser_plugins/parsers/LSSTParser.py
@@ -8,7 +8,7 @@ ERROR = 0.1  # UPDATE ME: Dummy value for elasticc tests
 
 def _e_ra(dec):
     try:
-        return ERROR / abs(math.cos(dec))
+        return ERROR / abs(math.cos(math.radians(dec)))
     except ZeroDivisionError:
         return float("nan")
 


### PR DESCRIPTION
## Summary of the changes

I corrected the Dec units used in cosine function for computing uncertainty in RA. Bug was described in https://github.com/alercebroker/pipeline/issues/198.

## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.