### PR TITLE
Remove internal xmatch in sorting hat, group by oid only

### DIFF
--- a/sorting_hat_step/README.md
+++ b/sorting_hat_step/README.md
@@ -7,12 +7,11 @@
 
 The step of the sorting hat is a step that names the alerts of astronomical survey. The flow of the step is showing in the following image:
 
-![sorting_hat](doc/sortinghat.png)
+TODO: Update figure
 
-1. Internal cross-match: Using a cKDTree we found the closest objects in the batch. Practically the step make an adjacency matrix and mark the neighbours in `1.5` arcsec. This cone search allows to obtain the same objects in the batch and thus perform fewer operations in the database. It also allows you to avoid concurrency problems when naming objects that are the same. 
-2. Find object id in the database: The first query to the database is get the known `oid` by survey. If exists this `oid` in database, the step retrieve the `aid` and assign it to the alert.
-3. Cone-search to the database: If the first query hasn't response, the step ask to historical database for nearest objects. If exists the nearest object with a radius of `1.5` arcsec If exists the nearest object with a radius of `1.5` arcsec, the step assign this `aid` to the alert.
-4. If there is no `oid` or a nearby object in the database, a new` aid` is created for the alert.
+1. Find object id in the database: The first query to the database is get the known `oid` by survey. If exists this `oid` in database, the step retrieve the `aid` and assign it to the alert.
+2. Cone-search to the database: If the first query hasn't response, the step ask to historical database for nearest objects. If exists the nearest object with a radius of `1.5` arcsec If exists the nearest object with a radius of `1.5` arcsec, the step assign this `aid` to the alert.
+3. If there is no `oid` or a nearby object in the database, a new` aid` is created for the alert.
 
 
 # Development guide

--- a/sorting_hat_step/sorting_hat_step/step.py
+++ b/sorting_hat_step/sorting_hat_step/step.py
@@ -107,13 +107,11 @@ class SortingHatStep(GenericStep):
         :param alerts: Dataframe of alerts
         :return: Dataframe of alerts with a new column called `aid` (alerce_id)
         """
-        # Internal cross-match that identifies same objects in own batch: create a new column named 'tmp_id'
         self.logger.info(f"Assigning AID to {len(alerts)} alerts")
-        alerts = wizard.internal_cross_match(alerts)
-        # Interaction with database: group all alerts with the same tmp_id and find/create alerce_id
+        alerts["aid"] = None
+        # Interaction with database: group all alerts with the same oid and find/create alerce_id
         alerts = wizard.find_existing_id(self.mongo_driver, alerts)
         if self.run_conesearch:
             alerts = wizard.find_id_by_conesearch(self.mongo_driver, alerts)
         alerts = wizard.generate_new_id(alerts)
-        alerts.drop(columns=["tmp_id"], inplace=True)
         return alerts

--- a/sorting_hat_step/sorting_hat_step/utils/wizard.py
+++ b/sorting_hat_step/sorting_hat_step/utils/wizard.py
@@ -106,9 +106,9 @@ def find_existing_id(db: MongoConnection, alerts: pd.DataFrame):
 
     Input:
             oid    aid
-        0   A      
-        1   B      
-        2   C      
+        0   A
+        1   B
+        2   C
 
     Output:
             oid    aid

--- a/sorting_hat_step/sorting_hat_step/utils/wizard.py
+++ b/sorting_hat_step/sorting_hat_step/utils/wizard.py
@@ -4,7 +4,6 @@ import logging
 
 import numpy as np
 import pandas as pd
-from scipy.spatial import cKDTree
 
 from ..database import MongoConnection, PsqlConnection
 from .database import (
@@ -101,50 +100,21 @@ def id_generator(ra: float, dec: float) -> int:
     return aid
 
 
-def internal_cross_match(
-    data: pd.DataFrame, ra_col="ra", dec_col="dec"
-) -> pd.DataFrame:
-    """
-    Do an internal cross-match in data input (batch vs batch) to get the closest objects. This method uses
-    cKDTree class to get the nearest object(s). Returns a new dataframe with another column named `tmp_id` to
-    reference unique objects and a column `aid` filled with `None`
-    """
-    data = data.copy()
-    radius = RADIUS / 3600
-    values = data[[ra_col, dec_col]].to_numpy()
-    tree = cKDTree(values)
-
-    # Put the index as a tmp_id
-    data["tmp_id"] = data.index
-    # Get unique object_ids
-    _, idx = np.unique(data["oid"], return_inverse=True)
-    data["tmp_id"] = data.index[idx]
-
-    # Sort all closest pairs to ensure idx of i increases after than j
-    close_pairs = sorted((_ for _ in tree.query_pairs(radius)), key=lambda x: x[0])
-    for i, j in close_pairs:
-        data.loc[j, "tmp_id"] = data["tmp_id"][i]
-
-    data["aid"] = None
-
-    return data
-
-
 def find_existing_id(db: MongoConnection, alerts: pd.DataFrame):
     """
     The aid column will be assigned the existing alerce id obtained from the database (if found).
 
     Input:
-            oid    tmp_id  aid
-        0   A      X
-        1   B      X
-        2   C      Y
+            oid    aid
+        0   A      
+        1   B      
+        2   C      
 
     Output:
-            oid    tmp_id  aid
-        0   A      X      aid1
-        1   B      X      aid1
-        2   C      Y      None
+            oid    aid
+        0   A      aid1
+        1   B      aid2
+        2   C      None
     """
     alerts = alerts.copy()
     if "aid" not in alerts:
@@ -155,7 +125,7 @@ def find_existing_id(db: MongoConnection, alerts: pd.DataFrame):
         return alerts
 
     count = 0
-    for tmp_id, group in alerts_wo_aid.groupby("tmp_id"):
+    for oid, group in alerts_wo_aid.groupby("oid"):
         aid = oid_query(db, group["oid"].unique().tolist())
         count += group.index.size if aid else 0
         alerts_wo_aid.loc[group.index, "aid"] = aid
@@ -169,16 +139,16 @@ def find_id_by_conesearch(db: MongoConnection, alerts: pd.DataFrame):
     """Assigns aid based on a conesearch in the database.
 
     Input:
-            oid    tmp_id  aid   ra   dec
-        0   A      X     aid1   123   456
-        1   B      X     aid1   123   456
-        2   C      Y     None   123   456
+            oid    aid   ra   dec
+        0   A      aid1   123   456
+        1   B      aid2   123   456
+        2   C      None   123   456
 
     Output:
-            oid    tmp_id  aid   ra   dec
-        0   A      X     aid1   123   456
-        1   B      X     aid1   123   456
-        2   C      Y     aid2   123   456
+            oid    aid   ra   dec
+        0   A      aid1   123   456
+        1   B      aid2   123   456
+        2   C      aid3   123   456
     """
     alerts = alerts.copy()
     if "aid" not in alerts:
@@ -189,7 +159,7 @@ def find_id_by_conesearch(db: MongoConnection, alerts: pd.DataFrame):
         return alerts
 
     count = 0
-    for tmp_id, group in alerts_wo_aid.groupby("tmp_id"):
+    for oid, group in alerts_wo_aid.groupby("oid"):
         aid = conesearch_query(db, group["ra"].iloc[0], group["dec"].iloc[0], RADIUS)
         count += group.index.size if aid else 0
         alerts_wo_aid.loc[group.index, "aid"] = aid
@@ -201,20 +171,20 @@ def find_id_by_conesearch(db: MongoConnection, alerts: pd.DataFrame):
 
 def generate_new_id(alerts: pd.DataFrame):
     """
-    Assigns aid column to a dataframe that has tmp_id column.
+    Assigns aid column to a dataframe that has oid column.
     The aid column will be a new generated alerce id.
 
     Input:
-            oid    tmp_id  aid   ra   dec
-        0   A      X     aid1   123   456
-        1   B      X     aid1   123   456
-        2   C      Y     None   123   456
+            oid    aid   ra   dec
+        0   A      aid1   123   456
+        1   B      aid2   123   456
+        2   C      None   123   456
 
     Output:
-            oid    tmp_id  aid   ra   dec
-        0   A      X     aid1   123   456
-        1   B      X     aid1   123   456
-        2   C      Y     ALid   123   456
+            oid    aid   ra   dec
+        0   A      aid1   123   456
+        1   B      aid2   123   456
+        2   C      ALid   123   456
     """
     alerts = alerts.copy()
     if "aid" not in alerts:
@@ -225,7 +195,7 @@ def generate_new_id(alerts: pd.DataFrame):
         return alerts
 
     count = 0
-    for tmp_id, group in alerts_wo_aid.groupby("tmp_id"):
+    for oid, group in alerts_wo_aid.groupby("oid"):
         id_ = id_generator(group["ra"].iloc[0], group["dec"].iloc[0])
         alerts_wo_aid.loc[group.index, "aid"] = f"AL{time.strftime('%y')}{encode(id_)}"
         count += 1

--- a/sorting_hat_step/tests/unittest/test_step.py
+++ b/sorting_hat_step/tests/unittest/test_step.py
@@ -86,7 +86,6 @@ class RunConesearchTestCase(unittest.TestCase):
         step = SortingHatStep(config=step_config, mongo_connection=self.mock_db)
         step.add_aid(self.dataframe)  # the wizzard is mocked
 
-        mock_wizzard.internal_cross_match.assert_called_once()
         mock_wizzard.find_existing_id.assert_called_once()
         mock_wizzard.find_id_by_conesearch.assert_called_once()
         mock_wizzard.generate_new_id.assert_called_once()
@@ -104,7 +103,6 @@ class RunConesearchTestCase(unittest.TestCase):
         step = SortingHatStep(config=step_config, mongo_connection=self.mock_db)
         step.add_aid(self.dataframe)  # the wizzard is mocked
 
-        mock_wizzard.internal_cross_match.assert_called_once()
         mock_wizzard.find_existing_id.assert_called_once()
         mock_wizzard.find_id_by_conesearch.assert_called_once()
         mock_wizzard.generate_new_id.assert_called_once()
@@ -121,7 +119,6 @@ class RunConesearchTestCase(unittest.TestCase):
         step = SortingHatStep(config=step_config, mongo_connection=self.mock_db)
         step.add_aid(self.dataframe)  # the wizzard is mocked
 
-        mock_wizzard.internal_cross_match.assert_called_once()
         mock_wizzard.find_existing_id.assert_called_once()
         mock_wizzard.find_id_by_conesearch.assert_not_called()
         mock_wizzard.generate_new_id.assert_called_once()

--- a/sorting_hat_step/tests/unittest/test_wizard.py
+++ b/sorting_hat_step/tests/unittest/test_wizard.py
@@ -31,46 +31,6 @@ class SortingHatTestCase(unittest.TestCase):
         aid_5 = wizard.id_generator(359 + 360, -1)
         self.assertEqual(aid_4, aid_5)
 
-    def test_internal_cross_match_no_closest_objects(self):
-        # Test with 500 unique objects (no closest objects) random.seed set in data.batch.py (1313)
-        example_batch = generate_batch_ra_dec(500)
-        batch = wizard.internal_cross_match(example_batch)
-        self.assertSetEqual(
-            set(batch.index), set(batch["tmp_id"])
-        )  # The index must be equal to tmp_id
-        self.assertEqual(len(batch["oid"].unique()), 500)
-
-    def test_internal_cross_match_closest_objects(self):
-        # Test with 10 objects closest
-        example_batch = generate_batch_ra_dec(1, nearest=9)
-        batch = wizard.internal_cross_match(example_batch)
-        # Check 100 unique tmp_id
-        self.assertEqual(len(batch["tmp_id"].unique()), 1)
-
-    def test_internal_cross_match_same_oid(self):
-        # Test with 10 objects where 5 are close
-        example_batch = generate_batch_ra_dec(10)
-        example_batch.loc[:, "oid"] = "same_object"
-        batch = wizard.internal_cross_match(example_batch)
-        self.assertEqual(len(batch["tmp_id"].unique()), 1)
-
-    def test_internal_cross_match_two_objects_with_oid(self):
-        batch_1 = generate_batch_ra_dec(1, nearest=9)
-        batch_1.loc[:, "oid"] = "same_object_1"
-        batch_2 = generate_batch_ra_dec(10)
-        batch_2.loc[:, "oid"] = "same_object_2"
-        batch = pd.concat([batch_1, batch_2], ignore_index=True)
-        batch_xmatched = wizard.internal_cross_match(batch)
-        self.assertEqual(len(batch_xmatched["tmp_id"].unique()), 2)
-        self.assertEqual(len(batch_xmatched["tmp_id"]), 20)
-
-    def test_internal_cross_match_repeating_oid_and_closest(self):
-        batch = generate_batch_ra_dec(1, nearest=9)
-        batch.loc[:, "oid"] = "same_object_1"
-        batch_xmatched = wizard.internal_cross_match(batch)
-        self.assertEqual(len(batch_xmatched["tmp_id"].unique()), 1)
-        self.assertEqual(len(batch_xmatched["tmp_id"]), 10)
-
     @mock.patch("sorting_hat_step.utils.wizard.oid_query")
     def test_find_existing_id(self, mock_query):
         alerts = pd.DataFrame(

--- a/sorting_hat_step/tests/unittest/test_wizard.py
+++ b/sorting_hat_step/tests/unittest/test_wizard.py
@@ -40,7 +40,7 @@ class SortingHatTestCase(unittest.TestCase):
                 {"oid": "C", "aid": None},
             ]
         )
-        mock_query.side_effect = ["aid1", None]
+        mock_query.side_effect = ["aid1", "aid1", None]
         response = wizard.find_existing_id(self.mock_db, alerts)
         assert (response["aid"].values == ["aid1", "aid1", None]).all()
 
@@ -48,9 +48,9 @@ class SortingHatTestCase(unittest.TestCase):
     def test_find_id_by_conesearch(self, mock_query):
         alerts = pd.DataFrame(
             [
-                {"oid": "A", "tmp_id": "X", "aid": "aid1", "ra": 123, "dec": 456},
-                {"oid": "B", "tmp_id": "X", "aid": "aid1", "ra": 123, "dec": 456},
-                {"oid": "C", "tmp_id": "Y", "aid": None, "ra": 123, "dec": 456},
+                {"oid": "A", "aid": "aid1", "ra": 123, "dec": 456},
+                {"oid": "B", "aid": "aid1", "ra": 123, "dec": 456},
+                {"oid": "C", "aid": None, "ra": 123, "dec": 456},
             ],
         )
         mock_query.side_effect = ["aid2", "aid2"]
@@ -61,9 +61,9 @@ class SortingHatTestCase(unittest.TestCase):
     def test_find_id_by_conesearch_without_found_aid(self, mock_query):
         alerts = pd.DataFrame(
             [
-                {"oid": "A", "tmp_id": "X", "aid": "aid1", "ra": 123, "dec": 456},
-                {"oid": "B", "tmp_id": "X", "aid": "aid1", "ra": 123, "dec": 456},
-                {"oid": "C", "tmp_id": "Y", "aid": None, "ra": 123, "dec": 456},
+                {"oid": "A", "aid": "aid1", "ra": 123, "dec": 456},
+                {"oid": "B", "aid": "aid1", "ra": 123, "dec": 456},
+                {"oid": "C", "aid": None, "ra": 123, "dec": 456},
             ],
         )
         mock_query.side_effect = [None]
@@ -73,9 +73,9 @@ class SortingHatTestCase(unittest.TestCase):
     def test_generate_new_id(self):
         alerts = pd.DataFrame(
             [
-                {"oid": "A", "tmp_id": "X", "aid": "aid1", "ra": 123, "dec": 456},
-                {"oid": "B", "tmp_id": "X", "aid": "aid1", "ra": 123, "dec": 456},
-                {"oid": "C", "tmp_id": "Y", "aid": None, "ra": 123, "dec": 456},
+                {"oid": "A", "aid": "aid1", "ra": 123, "dec": 456},
+                {"oid": "B", "aid": "aid1", "ra": 123, "dec": 456},
+                {"oid": "C", "aid": None, "ra": 123, "dec": 456},
             ],
         )
         response = wizard.generate_new_id(alerts)

--- a/sorting_hat_step/tests/unittest/test_wizard.py
+++ b/sorting_hat_step/tests/unittest/test_wizard.py
@@ -35,9 +35,9 @@ class SortingHatTestCase(unittest.TestCase):
     def test_find_existing_id(self, mock_query):
         alerts = pd.DataFrame(
             [
-                {"oid": "A", "tmp_id": "X", "aid": None},
-                {"oid": "B", "tmp_id": "X", "aid": None},
-                {"oid": "C", "tmp_id": "Y", "aid": None},
+                {"oid": "A", "aid": None},
+                {"oid": "B", "aid": None},
+                {"oid": "C", "aid": None},
             ]
         )
         mock_query.side_effect = ["aid1", None]


### PR DESCRIPTION
## Summary of the changes

I removed the internal xmatch previously done for finding the aid, as it produces conflicts for oids that are too close in a given batch (in the long term it groups different oids in the same aid and/or divides oids in separate aids). Bug was described in https://github.com/alercebroker/pipeline/issues/225.


## Observations

This fix was decided based on conflicted objects in the ELAsTiCC2 stream and ZTF stream, inspecting the production MongoDBs for each case. The effect on ATLAS objects has not been inspected.


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->