### PR TITLE
Prv time idea

### DIFF
--- a/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
+++ b/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
@@ -29,7 +29,7 @@ class GenericAlert:
 
     def __getitem__(self, item):
         return self.__getattribute__(item)
-    
+
     def to_dict(self):
         generic_alert_dict = {
             "oid": self.oid,
@@ -51,6 +51,7 @@ class GenericAlert:
         }
         return generic_alert_dict
 
+
 @dataclass
 class GenericNonDetection:
     """Non detection of astronomical surveys."""
@@ -66,7 +67,7 @@ class GenericNonDetection:
 
     def __getitem__(self, item):
         return self.__getattribute__(item)
-    
+
     def to_dict(self):
         generic_non_detection_dict = {
             "oid": self.oid,
@@ -80,6 +81,7 @@ class GenericNonDetection:
         }
 
         return generic_non_detection_dict
+
 
 class SurveyParser(abc.ABC):
     """Base class for survey parsing. Subclasses are intended to be static.

--- a/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
+++ b/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
@@ -29,7 +29,27 @@ class GenericAlert:
 
     def __getitem__(self, item):
         return self.__getattribute__(item)
-
+    
+    def to_dict(self):
+        generic_alert_dict = {
+            "oid": self.oid,
+            "tid": self.tid,
+            "sid": self.sid,
+            "pid": self.pid,
+            "candid": self.candid,
+            "mjd": self.mjd,
+            "fid": self.fid,
+            "ra": self.ra,
+            "dec": self.dec,
+            "mag": self.mag,
+            "e_mag": self.e_mag,
+            "isdiffpos": self.isdiffpos,
+            "e_ra": self.e_ra,
+            "e_dec": self.e_dec,
+            "extra_fields": self.extra_fields,
+            "stamps": self.stamps,
+        }
+        return generic_alert_dict
 
 @dataclass
 class GenericNonDetection:
@@ -46,7 +66,20 @@ class GenericNonDetection:
 
     def __getitem__(self, item):
         return self.__getattribute__(item)
+    
+    def to_dict(self):
+        generic_non_detection_dict = {
+            "oid": self.oid,
+            "tid": self.tid,
+            "sid": self.sid,
+            "mjd": self.mjd,
+            "fid": self.fid,
+            "diffmaglim": self.diffmaglim,
+            "extra_fields": self.extra_fields,
+            "stamps": self.stamps,
+        }
 
+        return generic_non_detection_dict
 
 class SurveyParser(abc.ABC):
     """Base class for survey parsing. Subclasses are intended to be static.

--- a/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
+++ b/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
@@ -49,7 +49,7 @@ class ZTFPreviousDetectionsParser(SurveyParser):
     def parse(cls, message: dict, oid: str) -> dict:
         message = message.copy()
         message["objectId"] = oid
-        return asdict(cls.parse_message(message))
+        return cls.parse_message(message).to_dict()
 
 
 class ZTFForcedPhotometryParser(SurveyParser):
@@ -84,7 +84,7 @@ class ZTFForcedPhotometryParser(SurveyParser):
 
         message["ra"] = ra
         message["dec"] = dec
-        return asdict(cls.parse_message(message))
+        return cls.parse_message(message).to_dict()
 
 
 class ZTFNonDetectionsParser(SurveyParser):
@@ -103,7 +103,7 @@ class ZTFNonDetectionsParser(SurveyParser):
     def parse(cls, message: dict, oid: str) -> dict:
         message = message.copy()
         message["objectId"] = oid
-        return asdict(cls.parse_message(message))
+        return cls.parse_message(message).to_dict()
 
 
 def extract_detections_and_non_detections(alert: dict) -> dict:


### PR DESCRIPTION
## Summary of the changes

Replacing the asdict call with a to_dict method in the generic dataclases for alrts and non detection with the hope of improving performance

## Observations

The tests were made in local and with a clock. But the difference is sifnificant enough in my opinion.
The original step proccesed 1500 messages in 5 minutes. 
This refactor process 8293 messages in 5 minutes

## Screensshots
![Original step profile](https://github.com/alercebroker/pipeline/assets/17658075/b46b845d-49a4-4e2a-85e7-27de8607eefa)
The important part is that most of the time the step is running asdict

![after_fix](https://github.com/alercebroker/pipeline/assets/17658075/d51e0559-7378-43d9-8420-c50ec1b67cda)
In this prifile we see other components of the step apear.
