### PR TITLE
Refactor prv candidate and forced photometry parsers

### DIFF
--- a/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
+++ b/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
@@ -1,6 +1,6 @@
 import abc
 import functools
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import Dict, Sequence, Set
 
 from .mapper import Mapper
@@ -29,6 +29,15 @@ class GenericAlert:
 
     def __getitem__(self, item):
         return self.__getattribute__(item)
+
+    def update(self, other: dict) -> None:
+        """Update the alert with the values from `other`"""
+        for k, v in other.items():
+            self.__setattr__(k, v)
+
+    def asdict(self) -> dict:
+        """Return the alert as a dictionary"""
+        return asdict(self)
 
 
 @dataclass

--- a/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
+++ b/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
@@ -30,11 +30,6 @@ class GenericAlert:
     def __getitem__(self, item):
         return self.__getattribute__(item)
 
-    def update(self, other: dict) -> None:
-        """Update the alert with the values from `other`"""
-        for k, v in other.items():
-            self.__setattr__(k, v)
-
     def asdict(self) -> dict:
         """Return the alert as a dictionary"""
         return asdict(self)
@@ -55,6 +50,10 @@ class GenericNonDetection:
 
     def __getitem__(self, item):
         return self.__getattribute__(item)
+
+    def asdict(self) -> dict:
+        """Return the alert as a dictionary"""
+        return asdict(self)
 
 
 class SurveyParser(abc.ABC):

--- a/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
+++ b/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
@@ -97,7 +97,7 @@ class ZTFForcedPhotometryParser(SurveyParser):
     @classmethod
     def parse_message(cls, forced_photometry: dict, alert: dict) -> dict:
         fpcopy = forced_photometry.copy()
-        fpcopy["candid"] = alert["oid"] + forced_photometry["pid"]
+        fpcopy["candid"] = alert["oid"] + str(forced_photometry["pid"])
         fpcopy["magpsf"], fpcopy["sigmapsf"] = cls.__calculate_mag(fpcopy)
         fpcopy["objectId"] = alert["oid"]
 

--- a/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
+++ b/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
@@ -152,7 +152,7 @@ def extract_detections_and_non_detections(alert: dict) -> dict:
         if ZTFPreviousDetectionsParser.can_parse(candidate)
     ]
     non_detections = [
-        ZTFNonDetectionsParser.parse_message(candidate, oid)
+        ZTFNonDetectionsParser.parse_message(candidate, alert)
         for candidate in prv_candidates
         if ZTFNonDetectionsParser.can_parse(candidate)
     ]

--- a/prv_candidates_step/tests/integration/conftest.py
+++ b/prv_candidates_step/tests/integration/conftest.py
@@ -103,7 +103,7 @@ def kafka_consumer():
                 "enable.partition.eof": True,
             },
             "TOPICS": ["prv-candidates"],
-            "TIMEOUT": 5,
+            "TIMEOUT": 0,
         }
     )
     yield consumer
@@ -120,7 +120,7 @@ def scribe_consumer():
                 "enable.partition.eof": True,
             },
             "TOPICS": ["w_non_detections"],
-            "TIMEOUT": 10,
+            "TIMEOUT": 0,
         }
     )
     yield consumer

--- a/prv_candidates_step/tests/unit/test_parsers.py
+++ b/prv_candidates_step/tests/unit/test_parsers.py
@@ -2,6 +2,7 @@ from prv_candidates_step.core.strategy.ztf import ZTFNonDetectionsParser
 from prv_candidates_step.core.strategy.ztf import ZTFPreviousDetectionsParser
 from fastavro.utils import generate_many
 from fastavro.schema import load_schema
+from fastavro.repository.base import SchemaRepositoryError
 from prv_candidates_step.core.strategy.ztf import (
     extract_detections_and_non_detections as ztf_extract,
 )
@@ -12,10 +13,23 @@ import pickle
 
 
 def test_prv_detections_parser():
-    schema = load_schema("tests/shared/ztf_prv_candidate_schema.avsc")
+    try:
+        schema = load_schema("tests/shared/ztf_prv_candidate_schema.avsc")
+    except SchemaRepositoryError:
+        schema = load_schema(
+            "prv_candidates_step/tests/shared/ztf_prv_candidate_schema.avsc"
+        )
     data = list(generate_many(schema, 1))
     data = list(map(lambda x: {**x, "fid": 1}, data))
-    result = ZTFPreviousDetectionsParser.parse(data[0], "oid")
+    result = ZTFPreviousDetectionsParser.parse_message(
+        data[0],
+        {
+            "aid": "aid",
+            "oid": "oid",
+            "candid": "123",
+            "extra_fields": {"ef1": 1},
+        },
+    )
     assert result["oid"] == "oid"
 
 

--- a/prv_candidates_step/tests/unit/test_parsers.py
+++ b/prv_candidates_step/tests/unit/test_parsers.py
@@ -60,8 +60,18 @@ def test_ztf_extract_detections_and_non_detections():
 
 
 def test_elasticc_extract_detections_and_non_detections():
-    dia_source_schema = load_schema("tests/shared/elasticc_prv_candidate.avsc")
-    forced_schema = load_schema("tests/shared/elasticc_forced_schema.avsc")
+    try:
+        dia_source_schema = load_schema("tests/shared/elasticc_prv_candidate.avsc")
+    except SchemaRepositoryError:
+        dia_source_schema = load_schema(
+            "prv_candidates_step/tests/shared/elasticc_prv_candidate.avsc"
+        )
+    try:
+        forced_schema = load_schema("tests/shared/elasticc_forced_schema.avsc")
+    except SchemaRepositoryError:
+        forced_schema = load_schema(
+            "prv_candidates_step/tests/shared/elasticc_forced_schema.avsc"
+        )
     prv_dia_sources = list(generate_many(dia_source_schema, 1))
     forced_sources = list(generate_many(forced_schema, 1))
     alert = {

--- a/prv_candidates_step/tests/unit/test_schema.py
+++ b/prv_candidates_step/tests/unit/test_schema.py
@@ -1,8 +1,12 @@
 from fastavro import schema, utils
+from fastavro.repository.base import SchemaRepositoryError
 
 
 def test_load_schema():
-    loaded = schema.load_schema("schema.avsc")
+    try:
+        loaded = schema.load_schema("schema.avsc")
+    except SchemaRepositoryError:
+        loaded = schema.load_schema("prv_candidates_step/schema.avsc")
     assert isinstance(loaded, dict)
     assert "aid" == loaded["fields"][0]["name"]
     assert "detections" == loaded["fields"][1]["name"]
@@ -10,7 +14,10 @@ def test_load_schema():
 
 
 def test_data():
-    loaded = schema.load_schema("schema.avsc")
+    try:
+        loaded = schema.load_schema("schema.avsc")
+    except SchemaRepositoryError:
+        loaded = schema.load_schema("prv_candidates_step/schema.avsc")
     data = utils.generate_one(loaded)
     assert "detections" in data
     assert "non_detections" in data


### PR DESCRIPTION
## Summary of the changes

Refactor the ZTF strategy to respect the SurveyParser interface and simplify the detection, non detection and force photometry extraction process, delegating it to the parser.

## Observations

The parsers still live in the prv_candidates_step code instead of the survey_parser_plugins lib. This could be refactored in a follow up PR.

## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.