### PR TITLE
fix(magstats-step): works with non ZTF data

### DIFF
--- a/magstats_step/magstats_step/step.py
+++ b/magstats_step/magstats_step/step.py
@@ -42,6 +42,8 @@ class MagstatsStep(GenericStep):
 
     def _execute_ztf(self, messages: dict):
         ztf_detections = list(filter(lambda d: d["sid"] == "ZTF", messages["detections"]))
+        if not len(ztf_detections):
+            return {}
         obj_calculator = ObjectStatistics(ztf_detections)
         stats = obj_calculator.generate_statistics(self.excluded).replace({np.nan: None})
         stats = stats.to_dict("index")


### PR DESCRIPTION
-------

## Summary of the changes

Fixes case when processing stream other than ZTF.

Closes #273


## Observations

When ZTF processing was introduced it didn't account for the previous non ZTF data.


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.