### PR TITLE
fix: now it checks if messages were sent + cleaning prv candidates be…

### DIFF
--- a/correction_step/correction/_step/step.py
+++ b/correction_step/correction/_step/step.py
@@ -9,8 +9,6 @@ from apf.core.step import GenericStep
 
 from ..core.corrector import Corrector
 
-from pprint import pprint
-
 
 class CorrectionStep(GenericStep):
     """Step that applies magnitude correction to new alert and previous candidates.

--- a/libs/apf/apf/core/step.py
+++ b/libs/apf/apf/core/step.py
@@ -406,11 +406,13 @@ class GenericStep(abc.ABC):
             to_produce = [result]
         else:
             to_produce = result
+        count = 0
         for prod_message in to_produce:
-            self.producer.produce(prod_message)
-            n_messages += 1
+            count += 1
+            flush = count == len(to_produce)
+            self.producer.produce(prod_message, flush=flush)
         if not isinstance(self.producer, DefaultProducer):
-            self.logger.info(f"Produced {n_messages} messages")
+            self.logger.info(f"Produced {count} messages")
 
     def set_producer_key_field(self, key_field: str):
         """

--- a/libs/apf/apf/producers/kafka.py
+++ b/libs/apf/apf/producers/kafka.py
@@ -145,6 +145,20 @@ class KafkaProducer(GenericProducer):
         The producer will have a key_field attribute that will be either None, or some specified value,
         and will use that for each produce() call.
         """
+
+        def acked(err, msg):
+            self.logger.debug("Message produced")
+            if err is not None:
+                if isinstance(err, BufferError):
+                    self.logger.error(f"Error producing message: {err}")
+                    self.logger.error("Calling poll to empty queue and producing again")
+                    self.producer.flush(1)
+                    self.producer.produce(
+                        topic, value=msg, key=key, callback=acked, **kwargs
+                    )
+                else:
+                    raise err
+
         key = None
         if message:
             key = message[self.key_field] if self.key_field else None
@@ -152,14 +166,12 @@ class KafkaProducer(GenericProducer):
         if self.dynamic_topic:
             self.topic = self.topic_strategy.get_topics()
         for topic in self.topic:
-            try:
-                self.producer.produce(topic, value=message, key=key, **kwargs)
-                self.producer.poll(0)
-            except BufferError as e:
-                self.logger.info(f"Error producing message: {e}")
-                self.logger.info("Calling poll to empty queue and producing again")
-                self.producer.flush()
-                self.producer.produce(topic, value=message, key=key, **kwargs)
+            flush = kwargs.pop("flush", False)
+            self.producer.produce(
+                topic, value=message, key=key, callback=acked, **kwargs
+            )
+            if flush:
+                self.producer.flush(1)
 
     def __del__(self):
         self.logger.info("Waiting to produce last messages")

--- a/libs/apf/apf/producers/kafka.py
+++ b/libs/apf/apf/producers/kafka.py
@@ -171,7 +171,7 @@ class KafkaProducer(GenericProducer):
                 topic, value=message, key=key, callback=acked, **kwargs
             )
             if flush:
-                self.producer.flush(1)
+                self.producer.flush()
 
     def __del__(self):
         self.logger.info("Waiting to produce last messages")

--- a/prv_candidates_step/prv_candidates_step/core/strategy/lsst.py
+++ b/prv_candidates_step/prv_candidates_step/core/strategy/lsst.py
@@ -44,7 +44,7 @@ class LSSTForcedPhotometryParser(SurveyParser):
 def extract_detections_and_non_detections(alert: dict) -> dict:
     prv_candidates = alert["extra_fields"].pop("prvDiaSources")
     prv_forced = alert["extra_fields"].pop("prvDiaForcedSources")
-    
+
     detections = [alert.copy()]
 
     aid, parent = alert["aid"], alert["candid"]

--- a/prv_candidates_step/prv_candidates_step/core/strategy/lsst.py
+++ b/prv_candidates_step/prv_candidates_step/core/strategy/lsst.py
@@ -42,13 +42,13 @@ class LSSTForcedPhotometryParser(SurveyParser):
 
 
 def extract_detections_and_non_detections(alert: dict) -> dict:
-    detections = [alert]
+    prv_candidates = alert["extra_fields"].pop("prvDiaSources")
+    prv_forced = alert["extra_fields"].pop("prvDiaForcedSources")
+    
+    detections = [alert.copy()]
 
     aid, parent = alert["aid"], alert["candid"]
     ra, dec = alert["ra"], alert["dec"]
-
-    prv_candidates = alert["extra_fields"].pop("prvDiaSources")
-    prv_forced = alert["extra_fields"].pop("prvDiaForcedSources")
 
     if "parent_candid" in alert["extra_fields"]:
         alert["extra_fields"].pop("parent_candid")

--- a/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
+++ b/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
@@ -162,12 +162,17 @@ class ZTFNonDetectionsParser(SurveyParser):
 
 
 def extract_detections_and_non_detections(alert: dict) -> dict:
+    prv_candidates = alert["extra_fields"].pop("prv_candidates")
+    prv_candidates = pickle.loads(prv_candidates) if prv_candidates else []
+
+    forced_photometries = alert["extra_fields"].pop("fp_hists", [])
+    forced_photometries = (
+        pickle.loads(forced_photometries) if forced_photometries else []
+    )
+
     acopy = alert.copy()
     detections = [acopy]
     non_detections = []
-
-    prv_candidates = alert["extra_fields"].pop("prv_candidates")
-    prv_candidates = pickle.loads(prv_candidates) if prv_candidates else []
 
     detections = detections + [
         ZTFPreviousDetectionsParser.parse_message(candidate, alert)
@@ -180,11 +185,6 @@ def extract_detections_and_non_detections(alert: dict) -> dict:
         if ZTFNonDetectionsParser.can_parse(candidate)
     ]
     alert["extra_fields"]["parent_candid"] = None
-
-    forced_photometries = alert["extra_fields"].pop("fp_hists", [])
-    forced_photometries = (
-        pickle.loads(forced_photometries) if forced_photometries else []
-    )
     detections = detections + [
         ZTFForcedPhotometryParser.parse_message(fp, alert)
         for fp in forced_photometries

--- a/prv_candidates_step/prv_candidates_step/step.py
+++ b/prv_candidates_step/prv_candidates_step/step.py
@@ -53,7 +53,9 @@ class PrvCandidatesStep(GenericStep):
                 msg["candid"] for msg in result if msg["candid"] == CANDID_SEARCH
             ]
             if len(with_candid) == 0:
-                raise Exception(f"=====\nALERT WITH CANDID {CANDID_SEARCH} DISAPPEARED!")
+                raise Exception(
+                    f"=====\nALERT WITH CANDID {CANDID_SEARCH} DISAPPEARED!"
+                )
         for alert in result:
             non_detections = alert["non_detections"]
             self.produce_scribe(non_detections)

--- a/prv_candidates_step/prv_candidates_step/step.py
+++ b/prv_candidates_step/prv_candidates_step/step.py
@@ -7,8 +7,6 @@ from apf.core.step import GenericStep
 
 from .core.extractor import PreviousCandidatesExtractor
 
-CANDID_SEARCH = str(os.getenv("CANDID_SEARCH", "2503521701415015005"))
-
 
 class PrvCandidatesStep(GenericStep):
     """PrvDetectionStep Description
@@ -35,27 +33,12 @@ class PrvCandidatesStep(GenericStep):
         return result
 
     def execute(self, messages):
-        with_candid = [
-            msg["candid"] for msg in messages if str(msg["candid"]) == CANDID_SEARCH
-        ]
-        if len(with_candid):
-            self.logger.info(f"CANDID {CANDID_SEARCH} FOUND!")
-            self.candid_found = True
-
         self.logger.info(f"Processing {len(messages)} alerts")
         extractor = PreviousCandidatesExtractor(messages)
         return extractor.extract_all()
 
     def post_execute(self, result: List[dict]):
         # Produce a message with the non_detections
-        if self.candid_found:
-            with_candid = [
-                msg["candid"] for msg in result if msg["candid"] == CANDID_SEARCH
-            ]
-            if len(with_candid) == 0:
-                raise Exception(
-                    f"=====\nALERT WITH CANDID {CANDID_SEARCH} DISAPPEARED!"
-                )
         for alert in result:
             non_detections = alert["non_detections"]
             self.produce_scribe(non_detections)

--- a/xmatch_step/tests/unittest/test_step.py
+++ b/xmatch_step/tests/unittest/test_step.py
@@ -83,6 +83,7 @@ class StepXmatchTest(unittest.TestCase):
         cls.step = XmatchStep(
             config=step_config,
         )
+        cls.step.producer.set_key_field.return_value = None
         cls.batch = generate_input_batch(20)  # I want 20 light  curves
 
     @mock.patch.object(XmatchClient, "execute")

--- a/xmatch_step/tests/unittest/test_step.py
+++ b/xmatch_step/tests/unittest/test_step.py
@@ -84,7 +84,7 @@ class StepXmatchTest(unittest.TestCase):
             config=step_config,
         )
 
-        def mock_method():
+        def mock_method(a):
             return None
 
         cls.step.producer.set_key_field = mock_method

--- a/xmatch_step/tests/unittest/test_step.py
+++ b/xmatch_step/tests/unittest/test_step.py
@@ -83,7 +83,11 @@ class StepXmatchTest(unittest.TestCase):
         cls.step = XmatchStep(
             config=step_config,
         )
-        cls.step.producer.set_key_field.return_value = None
+
+        def mock_method():
+            return None
+
+        cls.step.producer.set_key_field = mock_method
         cls.batch = generate_input_batch(20)  # I want 20 light  curves
 
     @mock.patch.object(XmatchClient, "execute")

--- a/xmatch_step/xmatch_step/step.py
+++ b/xmatch_step/xmatch_step/step.py
@@ -73,6 +73,7 @@ class XmatchStep(GenericStep):
                 [] if message["non_detections"] is None else message["non_detections"]
             )
             return message
+
         self.set_producer_key_field("aid")
         return list(map(_add_non_detection, result))
 

--- a/xmatch_step/xmatch_step/step.py
+++ b/xmatch_step/xmatch_step/step.py
@@ -74,7 +74,6 @@ class XmatchStep(GenericStep):
             )
             return message
 
-        self.set_producer_key_field("aid")
         return list(map(_add_non_detection, result))
 
     def request_xmatch(

--- a/xmatch_step/xmatch_step/step.py
+++ b/xmatch_step/xmatch_step/step.py
@@ -73,7 +73,7 @@ class XmatchStep(GenericStep):
                 [] if message["non_detections"] is None else message["non_detections"]
             )
             return message
-
+        self.set_producer_key_field("aid")
         return list(map(_add_non_detection, result))
 
     def request_xmatch(


### PR DESCRIPTION
## Summary of the changes

It tackles a bug where big messages failed without an error. This caused a big loss of data, even more when handling big datastreams like ELAsTiCC.


## Observations

 - Kafka Producer now flushes and checks if messages were sent successfully if set to.
 - Prv candidates step now deletes the previous candidates fields before setting it to be sent


## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.
