### PR TITLE
add error catching for missing features and a test

### DIFF
--- a/lc_classification_step/lc_classification/core/step.py
+++ b/lc_classification_step/lc_classification/core/step.py
@@ -140,7 +140,7 @@ class LateClassifier(GenericStep):
                     probabilities["probabilities"], probabilities["hierarchical"]
                 )
             except Exception as e:
-                print(e) # logger error?
+                self.logger.error(e)
                 return (
                     OutputDTO(DataFrame(), {"top": DataFrame(), "children": {}}),
                     messages,

--- a/lc_classification_step/lc_classification/core/step.py
+++ b/lc_classification_step/lc_classification/core/step.py
@@ -137,16 +137,19 @@ class LateClassifier(GenericStep):
                     model_input.features,
                 )
                 probabilities = OutputDTO(
-                    probabilities["probabilities"], probabilities["hierarchical"]
+                    probabilities["probabilities"],
+                    probabilities["hierarchical"],
                 )
             except Exception as e:
                 self.logger.error(e)
                 return (
-                    OutputDTO(DataFrame(), {"top": DataFrame(), "children": {}}),
+                    OutputDTO(
+                        DataFrame(), {"top": DataFrame(), "children": {}}
+                    ),
                     messages,
                     model_input.features,
                 )
-            
+
         else:
             try:
                 probabilities = self.model.predict(model_input)

--- a/lc_classification_step/lc_classification/core/step.py
+++ b/lc_classification_step/lc_classification/core/step.py
@@ -132,12 +132,21 @@ class LateClassifier(GenericStep):
         )
         self.logger.info("Doing inference")
         if self.isztf:
-            probabilities = self.model.predict_in_pipeline(
-                model_input.features,
-            )
-            probabilities = OutputDTO(
-                probabilities["probabilities"], probabilities["hierarchical"]
-            )
+            try:
+                probabilities = self.model.predict_in_pipeline(
+                    model_input.features,
+                )
+                probabilities = OutputDTO(
+                    probabilities["probabilities"], probabilities["hierarchical"]
+                )
+            except Exception as e:
+                print(e) # logger error?
+                return (
+                    OutputDTO(DataFrame(), {"top": DataFrame(), "children": {}}),
+                    messages,
+                    model_input.features,
+                )
+            
         else:
             try:
                 probabilities = self.model.predict(model_input)

--- a/lc_classification_step/tests/integration/test_step_ztf.py
+++ b/lc_classification_step/tests/integration/test_step_ztf.py
@@ -38,3 +38,32 @@ def test_step_ztf_result(
         command = json.loads(message["payload"])
         assert_command_is_correct(command)
         sconsumer.commit()
+
+
+@pytest.mark.ztf
+def test_step_ztf_no_features_result(
+    kafka_service,
+    produce_messages,
+    env_variables_ztf,
+    kafka_consumer: Callable[[str], KafkaConsumer],
+    scribe_consumer: Callable[[], KafkaConsumer],
+):
+    produce_messages("features_ztf", force_missing_features=True)
+    env_variables_ztf()
+
+    from settings import config
+
+    kconsumer = kafka_consumer("ztf")
+    sconsumer = scribe_consumer()
+
+    step = LateClassifier(config=config())
+    step.start()
+
+    for message in kconsumer.consume():
+        assert_ztf_object_is_correct(message)
+        kconsumer.commit()
+
+    for message in sconsumer.consume():
+        command = json.loads(message["payload"])
+        assert_command_is_correct(command)
+        sconsumer.commit()

--- a/lc_classification_step/tests/unit/test_step_ztf.py
+++ b/lc_classification_step/tests/unit/test_step_ztf.py
@@ -31,13 +31,19 @@ def test_step(step_factory_ztf):
 
 @pytest.mark.ztf
 def test_step_empty_features(step_factory_ztf):
+    from lc_classifier.classifier.models import HierarchicalRandomForest
+    model = HierarchicalRandomForest()
+    model.download_model()
+    model.load_model(model.MODEL_PICKLE_PATH)
     empty_features = []
     for msg in generate_messages_ztf():
         msg.pop("features")
         empty_features.append(msg)
     step = step_factory_ztf(empty_features)
+    step.model = model
     step.start()
     scribe_calls = step.scribe_producer.mock_calls
     assert scribe_calls == []
     calls = step.producer.mock_calls
     assert calls == []
+    assert False

--- a/lc_classification_step/tests/unit/test_step_ztf.py
+++ b/lc_classification_step/tests/unit/test_step_ztf.py
@@ -46,4 +46,3 @@ def test_step_empty_features(step_factory_ztf):
     assert scribe_calls == []
     calls = step.producer.mock_calls
     assert calls == []
-    assert False


### PR DESCRIPTION
## Summary of the changes

When no features are provider for the ztf lc classification a error breacks the step processing.
We must catch the error and generate a output for the step.


## Observations
unit test done
integration test pending
output message pending

