### PR TITLE
fix(prv-candidates): remove timestamp from detections

### DIFF
--- a/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
+++ b/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
@@ -57,9 +57,9 @@ class ZTFPreviousDetectionsParser(SurveyParser):
             if k not in cls._exclude_from_extra_fields()
         }
         extra_fields.update(alert["extra_fields"])
-        generic.pop("stamps", None)
         model = cls._Model(**generic, stamps=stamps, extra_fields=extra_fields)
         model = model.to_dict()
+        model.pop("stamps", None)
         model.update(
             {
                 "aid": alert["aid"],

--- a/prv_candidates_step/prv_candidates_step/step.py
+++ b/prv_candidates_step/prv_candidates_step/step.py
@@ -1,5 +1,4 @@
 import json
-import os
 from typing import List
 
 from apf.core import get_class
@@ -28,8 +27,20 @@ class PrvCandidatesStep(GenericStep):
         # monitoring
         self.candid_found = False
 
+    def _extract_timestamp(self, message):
+        def __extract_timestamp(detection):
+            detection.pop("timestamp", None)
+            return detection
+
+        dets = message["detections"]
+        dets = list(map(__extract_timestamp, dets))
+        message["detections"] = dets
+
+        return message
+
     def pre_produce(self, result: List[dict]):
         self.set_producer_key_field("aid")
+        result = list(map(self._extract_timestamp, result))
         return result
 
     def execute(self, messages):

--- a/prv_candidates_step/settings.py
+++ b/prv_candidates_step/settings.py
@@ -38,7 +38,7 @@ def settings_creator():
     }
 
     producer_config = {
-        "CLASS": "apf.producers.KafkaProducer",
+        "CLASS": os.getenv("PRODUCER_CLASS", "apf.producers.KafkaProducer"),
         "PARAMS": {
             "bootstrap.servers": os.environ["PRODUCER_SERVER"],
             "message.max.bytes": int(os.getenv("PRODUCER_MESSAGE_MAX_BYTES", 6291456)),

--- a/prv_candidates_step/tests/integration/conftest.py
+++ b/prv_candidates_step/tests/integration/conftest.py
@@ -55,6 +55,7 @@ def kafka_service(docker_ip, docker_services):
 
 @pytest.fixture
 def env_variables():
+    envcopy = os.environ.copy()
     random_string = uuid.uuid4().hex
 
     env_variables_dict = {
@@ -93,7 +94,8 @@ def env_variables():
     for key in env_variables_dict:
         os.environ[key] = env_variables_dict[key]
 
-    return env_variables_dict
+    yield env_variables_dict
+    os.environ = envcopy
 
 
 def produce_messages(topic):

--- a/prv_candidates_step/tests/integration/test_step.py
+++ b/prv_candidates_step/tests/integration/test_step.py
@@ -80,3 +80,12 @@ def test_works_with_batch(kafka_service, env_variables, kafka_consumer: KafkaCon
         assert_result_has_prv_detections(message)
         assert_result_has_alert(message)
         kafka_consumer.commit()
+
+
+def test_works_with_schemaless_producer(kafka_service, env_variables):
+    from scripts.run_step import step_creator
+    import os
+
+    os.environ["PRODUCER_CLASS"] = "apf.producers.KafkaSchemalessProducer"
+
+    step_creator().start()

--- a/schemas/prv_candidate_step/output.avsc
+++ b/schemas/prv_candidate_step/output.avsc
@@ -89,14 +89,24 @@
             },
             {
               "name": "parent_candid",
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             {
               "name": "extra_fields",
               "type": {
                 "default": {},
                 "type": "map",
-                "values": ["null", "int", "float", "string", "bytes", "boolean"]
+                "values": [
+                  "null",
+                  "int",
+                  "float",
+                  "string",
+                  "bytes",
+                  "boolean"
+                ]
               }
             }
           ]


### PR DESCRIPTION
-------

## Summary of the changes

Cleans output message from unneeded fields.

- Deletes timestamp field from detections
- Properly deletes stamps from prv candidates

Closes #296


## Observations

There is an optional environment variable for setting producer class.


## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.