### PR TITLE
Fixed wrong values in isclose when forcediffimflux and/or forcediffimfluxunc is -99999

### DIFF
--- a/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
+++ b/prv_candidates_step/prv_candidates_step/core/strategy/ztf.py
@@ -87,11 +87,11 @@ class ZTFForcedPhotometryParser(SurveyParser):
         mag = -2.5 * np.log10(np.abs(forcediffimflux)) + 23.9
         e_mag = 1.0857 * forcediffimfluxunc / np.abs(forcediffimflux)
 
-        if np.isclose(data["forcediffimflux"], _ZERO_MAG):
+        if np.isclose(data["forcediffimflux"], -99999):
             mag = _ZERO_MAG
             e_mag = _ZERO_MAG
 
-        if np.isclose(data["forcediffimfluxunc"], _ZERO_MAG):
+        if np.isclose(data["forcediffimfluxunc"], -99999):
             e_mag = _ZERO_MAG
 
         return mag, e_mag

--- a/prv_candidates_step/tests/unit/test_parsers.py
+++ b/prv_candidates_step/tests/unit/test_parsers.py
@@ -34,7 +34,9 @@ def test_prv_detections_parser():
     assert result["oid"] == "oid"
     assert result["aid"] == "aid"
     assert not result["has_stamp"]
-    assert result["extra_fields"]["ef1"] == 1
+    assert "ef1" not in result["extra_fields"]
+    assert "distnr" in result["extra_fields"]
+    # Other extra fields should be verified as well
     assert result["parent_candid"] == "123"
 
 
@@ -52,12 +54,25 @@ def test_ztf_extract_detections_and_non_detections():
         "oid": "oid",
         "candid": "123",
         "fid": 1,
-        "extra_fields": {"ef1": 1, "prv_candidates": pickle.dumps(data)},
+        "extra_fields": {
+            "ef1": 1,
+            "prv_candidates": pickle.dumps(data),
+            "distnr": -555,
+        },
     }
     result = ztf_extract(alert)
     assert len(result["detections"]) == 2
     for res in result["detections"]:
-        assert res["extra_fields"]["ef1"] == 1
+        assert (
+            "ef1" in res["extra_fields"]
+            if res["candid"] == "123"
+            else "ef1" not in res["extra_fields"]
+        )
+        assert (
+            res["extra_fields"]["distnr"] == -555
+            if res["candid"] == "123"
+            else res["extra_fields"]["distnr"] > 0
+        )
 
 
 def test_elasticc_extract_detections_and_non_detections():


### PR DESCRIPTION
## Summary of the changes

Conditions on forcediffimflux and forcediffimfluxunc were not met because they were compared to _ZERO_MAG, when it had to be -99999. Fixed this. Related to bug described in https://github.com/alercebroker/pipeline/issues/316 and PR in https://github.com/alercebroker/pipeline/pull/323.


## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->