### PR TITLE
[Sorting Hat] Refactor: set oid as object identifier

### DIFF
--- a/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
+++ b/libs/survey_parser_plugins/survey_parser_plugins/core/generic.py
@@ -1,6 +1,6 @@
 import abc
 import functools
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field
 from typing import Dict, Sequence, Set
 
 from .mapper import Mapper

--- a/sorting_hat_step/pyproject.toml
+++ b/sorting_hat_step/pyproject.toml
@@ -37,7 +37,7 @@ psycopg2-binary = "*"
 test-utils = { path = "../libs/test_utils", develop = true }
 
 [tool.black]
-line-length = 88
+line-length = 79
 
 [tool.pytest.ini_options]
 addopts = "-x"

--- a/sorting_hat_step/sorting_hat_step/step.py
+++ b/sorting_hat_step/sorting_hat_step/step.py
@@ -32,14 +32,14 @@ class SortingHatStep(GenericStep):
         Step lifecycle method.
         Format output that will be taken by the producer and set the producer key.
 
-        Calling self.set_producer_key_field("aid") will make that each message produced has the
-        aid value as key.
+        Calling self.set_producer_key_field("oid") will make that each message produced has the
+        oid value as key.
 
         For example if message looks like this:
 
-        message = {"aid": "ALabc123"}
+        message = {"oid": "abc123"}
 
-        Then, the produced kafka message will have "ALabc123" as key.
+        Then, the produced kafka message will have "abc123" as key.
 
         Parameters
         ----------
@@ -51,8 +51,10 @@ class SortingHatStep(GenericStep):
         output_result: pd.DataFrame
             The parsed data as defined by the config["PRODUCER_CONFIG"]["SCHEMA"]
         """
-        output_result = [parser.parse_output(alert) for _, alert in result.iterrows()]
-        self.set_producer_key_field("aid")
+        output_result = [
+            parser.parse_output(alert) for _, alert in result.iterrows()
+        ]
+        self.set_producer_key_field("oid")
         return output_result
 
     def _add_metrics(self, alerts: pd.DataFrame):
@@ -100,7 +102,9 @@ class SortingHatStep(GenericStep):
         psql_driver = None
         if self.use_psql:
             psql_driver = self.psql_driver
-        wizard.insert_empty_objects(self.mongo_driver, alerts, psql=psql_driver)
+        wizard.insert_empty_objects(
+            self.mongo_driver, alerts, psql=psql_driver
+        )
         return alerts
 
     def add_aid(self, alerts: pd.DataFrame) -> pd.DataFrame:

--- a/sorting_hat_step/sorting_hat_step/utils/database.py
+++ b/sorting_hat_step/sorting_hat_step/utils/database.py
@@ -69,7 +69,7 @@ def update_query(db: MongoConnection, records: List[dict]):
     for record in records:
         query = {"_id": record["_id"]}
         new_value = {
-            "$addToSet": {"oid": {"$each": record["oid"]}},
+            "$set": {"aid": record["aid"]},
         }
         db.database["object"].find_one_and_update(
             query, new_value, upsert=True, return_document=True
@@ -94,10 +94,14 @@ def insert_empty_objects_to_sql(db: PsqlConnection, records: List[Dict]):
         }
 
     oids = {
-        r["oid"]: format_extra_fields(r) for r in records if r["sid"].lower() == "ztf"
+        r["_id"]: format_extra_fields(r)
+        for r in records
+        if r["sid"].lower() == "ztf"
     }
     with db.session() as session:
-        to_insert = [{"oid": oid, **extra_fields} for oid, extra_fields in oids.items()]
+        to_insert = [
+            {"oid": oid, **extra_fields} for oid, extra_fields in oids.items()
+        ]
         statement = insert(Object).values(to_insert)
         statement = statement.on_conflict_do_update(
             "object_pkey",

--- a/sorting_hat_step/sorting_hat_step/utils/parser.py
+++ b/sorting_hat_step/sorting_hat_step/utils/parser.py
@@ -19,5 +19,7 @@ def parse_output(alert: pd.Series) -> dict:
     """
     alert = alert.replace({np.nan: None})
     alert_dict = alert.to_dict()
-    alert_dict["extra_fields"] = _parse_extra_fields(alert_dict["extra_fields"])
+    alert_dict["extra_fields"] = _parse_extra_fields(
+        alert_dict["extra_fields"]
+    )
     return alert_dict

--- a/sorting_hat_step/tests/unittest/test_wizard.py
+++ b/sorting_hat_step/tests/unittest/test_wizard.py
@@ -152,8 +152,41 @@ class SortingHatTestCase(unittest.TestCase):
         wizard.insert_empty_objects(self.mock_db, alerts)
 
         updated_records = [
-            {"oid": [10, 30], "_id": 0},
-            {"oid": [20], "_id": 1},
-            {"oid": [40], "_id": 2},
+            {
+                "_id": 10,
+                "aid": 0,
+                "sid": "ZTF",
+                "extra_fields": {},
+                "ra": 0,
+                "dec": 0,
+                "mjd": 0,
+            },
+            {
+                "_id": 20,
+                "aid": 1,
+                "sid": "ZTF",
+                "extra_fields": {},
+                "ra": 0,
+                "dec": 0,
+                "mjd": 0,
+            },
+            {
+                "_id": 30,
+                "aid": 0,
+                "sid": "ZTF",
+                "extra_fields": {},
+                "ra": 0,
+                "dec": 0,
+                "mjd": 0,
+            },
+            {
+                "_id": 40,
+                "aid": 2,
+                "sid": "ZTF",
+                "extra_fields": {},
+                "ra": 0,
+                "dec": 0,
+                "mjd": 0,
+            },
         ]
         insert_mock.assert_called_with(self.mock_db, updated_records)


### PR DESCRIPTION
## Summary of the changes

Uses oid instead of aid as object identifier

Closes #345

## If the change is BREAKING, please give more details about the breaking changes

The identifier on mongo documents, the `_id`, is now the objectId set by the survey. The aid is a field inside the document.

#### Components that need updates and steps to follow

All the other steps need to take this change into account.
The database schema will not be compatible with either steps or APIs

## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.