### PR TITLE
Refactor(Lightcurve Step): Use oid grouping instead of aid

### DIFF
--- a/libs/db-plugins/db_plugins/db/mongo/models.py
+++ b/libs/db-plugins/db_plugins/db/mongo/models.py
@@ -63,6 +63,7 @@ class Object(BaseModel):
     xmatch = SpecialField(lambda **kwargs: kwargs.get("xmatch", []))
 
     __table_args__ = [
+        IndexModel([("oid", ASCENDING)], name="oid"),
         IndexModel([("aid", ASCENDING)], name="aid"),
         IndexModel([("sid", ASCENDING)], name="sid"),
         IndexModel([("lastmjd", DESCENDING)], name="lastmjd"),

--- a/libs/db-plugins/db_plugins/db/mongo/models.py
+++ b/libs/db-plugins/db_plugins/db/mongo/models.py
@@ -63,7 +63,7 @@ class Object(BaseModel):
     xmatch = SpecialField(lambda **kwargs: kwargs.get("xmatch", []))
 
     __table_args__ = [
-        IndexModel([("oid", ASCENDING)], name="oid"),
+        IndexModel([("aid", ASCENDING)], name="aid"),
         IndexModel([("sid", ASCENDING)], name="sid"),
         IndexModel([("lastmjd", DESCENDING)], name="lastmjd"),
         IndexModel([("firstmjd", DESCENDING)], name="firstmjd"),
@@ -113,7 +113,8 @@ class Detection(BaseModelWithExtraFields):
     has_stamp = Field()
 
     __table_args__ = [
-        IndexModel([("aid", ASCENDING), ("oid", ASCENDING)]),
+        IndexModel([("oid", ASCENDING)]),
+        IndexModel([("aid", ASCENDING)]),
         IndexModel([("sid", ASCENDING)]),
     ]
     __tablename__ = "detection"
@@ -150,7 +151,8 @@ class ForcedPhotometry(BaseModelWithExtraFields):
     has_stamp = Field()
 
     __table_args__ = [
-        IndexModel([("aid", ASCENDING), ("oid", ASCENDING)], name="aid_oid"),
+        IndexModel([("oid", ASCENDING)], name="oid"),
+        IndexModel([("aid", ASCENDING)], name="aid"),
         IndexModel([("sid", ASCENDING)], name="sid"),
     ]
     __tablename__ = "forced_photometry"
@@ -174,7 +176,7 @@ class NonDetection(BaseModelWithExtraFields):
 
     __table_args__ = [
         IndexModel(
-            [("aid", ASCENDING), ("fid", ASCENDING), ("mjd", ASCENDING)],
+            [("oid", ASCENDING), ("fid", ASCENDING), ("mjd", ASCENDING)],
             name="unique",
             unique=True,
         ),

--- a/libs/test_utils/test_utils/fixtures.py
+++ b/libs/test_utils/test_utils/fixtures.py
@@ -57,6 +57,7 @@ def kafka_consumer():
                     "enable.partition.eof": "true",
                 },
                 "TOPICS": topics,
+                "exit_on_consume": True,
             }
         )
         return consumer

--- a/libs/test_utils/test_utils/utils.py
+++ b/libs/test_utils/test_utils/utils.py
@@ -2,7 +2,6 @@ from db_plugins.db.mongo.initialization import init_mongo_database
 from pymongo import MongoClient
 import psycopg2
 from confluent_kafka.admin import AdminClient, NewTopic
-import os
 
 
 def is_responsive_mongo():
@@ -30,8 +29,7 @@ def is_responsive_mongo():
         "AUTH_SOURCE": "test_db",
     }
     init_mongo_database(settings)
-    cols = [col for col in db.list_collections()]
-    print(cols)
+    db.list_collections()
     return True
 
 

--- a/lightcurve-step/lightcurve_step/database_mongo.py
+++ b/lightcurve-step/lightcurve_step/database_mongo.py
@@ -13,10 +13,10 @@ class DatabaseConnection:
         self.database = self.client[_database]
 
 
-def _get_mongo_detections(aids, db_mongo, parser) -> list:
+def _get_mongo_detections(oids, db_mongo, parser) -> list:
     db_detections = db_mongo.database[DETECTION].aggregate(
         [
-            {"$match": {"aid": {"$in": aids}}},
+            {"$match": {"oid": {"$in": oids}}},
             {
                 "$addFields": {
                     "candid": "$_id",
@@ -42,19 +42,19 @@ def _get_mongo_detections(aids, db_mongo, parser) -> list:
     return db_detections
 
 
-def _get_mongo_non_detections(aids, db_mongo, parser):
+def _get_mongo_non_detections(oids, db_mongo, parser):
     db_non_detections = db_mongo.database[NON_DETECTION].find(
-        {"aid": {"$in": aids}},
+        {"oid": {"$in": oids}},
         {"_id": False, "evilDocDbHack": False},
     )
     db_non_detections = parser(db_non_detections)
     return db_non_detections
 
 
-def _get_mongo_forced_photometries(aids, db_mongo, parser):
+def _get_mongo_forced_photometries(oids, db_mongo, parser):
     db_forced_photometries = db_mongo.database[FORCED_PHOTOMETRY].aggregate(
         [
-            {"$match": {"aid": {"$in": aids}}},
+            {"$match": {"oid": {"$in": oids}}},
             {
                 "$addFields": {
                     "candid": "$_id",

--- a/lightcurve-step/lightcurve_step/database_mongo.py
+++ b/lightcurve-step/lightcurve_step/database_mongo.py
@@ -13,7 +13,7 @@ class DatabaseConnection:
         self.database = self.client[_database]
 
 
-def _get_mongo_detections(aids, db_mongo):
+def _get_mongo_detections(aids, db_mongo, parser) -> list:
     db_detections = db_mongo.database[DETECTION].aggregate(
         [
             {"$match": {"aid": {"$in": aids}}},
@@ -38,18 +38,20 @@ def _get_mongo_detections(aids, db_mongo):
             },
         ]
     )
+    db_detections = parser(db_detections)
     return db_detections
 
 
-def _get_mongo_non_detections(aids, db_mongo):
+def _get_mongo_non_detections(aids, db_mongo, parser):
     db_non_detections = db_mongo.database[NON_DETECTION].find(
         {"aid": {"$in": aids}},
         {"_id": False, "evilDocDbHack": False},
     )
+    db_non_detections = parser(db_non_detections)
     return db_non_detections
 
 
-def _get_mongo_forced_photometries(aids, db_mongo):
+def _get_mongo_forced_photometries(aids, db_mongo, parser):
     db_forced_photometries = db_mongo.database[FORCED_PHOTOMETRY].aggregate(
         [
             {"$match": {"aid": {"$in": aids}}},
@@ -74,4 +76,5 @@ def _get_mongo_forced_photometries(aids, db_mongo):
             },
         ]
     )
+    db_forced_photometries = parser(db_forced_photometries)
     return db_forced_photometries

--- a/lightcurve-step/lightcurve_step/database_sql.py
+++ b/lightcurve-step/lightcurve_step/database_sql.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from typing import Callable, ContextManager
 
-from sqlalchemy import create_engine, select, text
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker, Session
 from db_plugins.db.sql.models import Detection, NonDetection, ForcedPhotometry
 
@@ -34,7 +34,7 @@ def default_parser(data, **kwargs):
 
 
 def _get_sql_detections(
-    oids: dict, db_sql: PSQLConnection, parser: Callable = default_parser
+    oids: list, db_sql: PSQLConnection, parser: Callable = default_parser
 ):
     if db_sql is None:
         return []
@@ -53,7 +53,9 @@ def _get_sql_non_detections(oids, db_sql, parser: Callable = default_parser):
         return parser(detections, oids=oids)
 
 
-def _get_sql_forced_photometries(oids, db_sql, parser: Callable = default_parser):
+def _get_sql_forced_photometries(
+    oids, db_sql, parser: Callable = default_parser
+):
     if db_sql is None:
         return []
     with db_sql.session() as session:

--- a/lightcurve-step/lightcurve_step/parser_mongo.py
+++ b/lightcurve-step/lightcurve_step/parser_mongo.py
@@ -1,0 +1,27 @@
+from pymongo.cursor import Cursor
+from .parser_utils import get_fid
+
+
+def parse_mongo_forced_photometry(forced_photometries: Cursor):
+    parsed_forced_photometry = list(forced_photometries)
+    return parsed_forced_photometry
+
+
+def parse_mongo_detection(detections: Cursor):
+    parsed_detections = list(detections)
+    parsed_detections = [
+        # assign candid as field candid if present, else assign _id as candid
+        # to comply with the legacy schema
+        {
+            **det,
+            "candid": str(det.get("candid", det.get("_id"))),
+            "fid": get_fid(det["fid"]),
+        }
+        for det in parsed_detections
+    ]
+    return parsed_detections
+
+
+def parse_mongo_non_detection(non_detections: Cursor):
+    parsed_non_detections = list(non_detections)
+    return parsed_non_detections

--- a/lightcurve-step/lightcurve_step/parser_sql.py
+++ b/lightcurve-step/lightcurve_step/parser_sql.py
@@ -1,0 +1,143 @@
+from db_plugins.db.mongo.models import (
+    Detection as MongoDetection,
+    NonDetection as MongoNonDetection,
+    ForcedPhotometry as MongoForcedPhotometry,
+)
+from .parser_utils import get_fid
+
+
+def parse_sql_detection(ztf_models: list, *, oids) -> list:
+    GENERIC_FIELDS = {
+        "tid",
+        "sid",
+        "aid",
+        "oid",
+        "pid",
+        "mjd",
+        "fid",
+        "ra",
+        "dec",
+        "isdiffpos",
+        "corrected",
+        "dubious",
+        "candid",
+        "parent_candid",
+        "has_stamp",
+    }
+    FIELDS_TO_REMOVE = [
+        "stellar",
+        "e_mag_corr",
+        "corrected",
+        "mag_corr",
+        "e_mag_corr_ext",
+        "dubious",
+        "magpsf",
+        "sigmapsf",
+        "magpsf_corr",
+        "sigmapsf_corr",
+        "sigmapsf_corr_ext",
+    ]
+
+    parsed_result = []
+    for det in ztf_models:
+        det: dict = det[0].__dict__
+        extra_fields = {}
+        parsed_det = {}
+        for field, value in det.items():
+            if field.startswith("_"):
+                continue
+            if field not in GENERIC_FIELDS:
+                extra_fields[field] = value
+            if field == "fid":
+                parsed_det[field] = get_fid(value)
+            else:
+                parsed_det[field] = value
+        parsed = MongoDetection(
+            **parsed_det,
+            aid=oids[det["oid"]],
+            sid="ZTF",
+            tid="ZTF",
+            mag=det["magpsf"],
+            e_mag=det["sigmapsf"],
+            mag_corr=det["magpsf_corr"],
+            e_mag_corr=det["sigmapsf_corr"],
+            e_mag_corr_ext=det["sigmapsf_corr_ext"],
+            extra_fields=extra_fields,
+            e_ra=-999,
+            e_dec=-999,
+        )
+        parsed["candid"] = parsed.pop("_id")
+
+        for field in FIELDS_TO_REMOVE:
+            parsed.pop(field, None)
+            parsed["extra_fields"].pop(field, None)
+
+        parsed_result.append({**parsed, "forced": False, "new": False})
+
+    return parsed_result
+
+
+def parse_sql_non_detection(ztf_models: list, *, oids) -> list:
+    FID = {1: "g", 2: "r", 0: None, 12: "gr", 3: "i"}
+    non_dets = []
+    for non_det in ztf_models:
+        non_det = non_det[0].__dict__
+        mongo_non_detection = MongoNonDetection(
+            _id="jej",
+            tid="ZTF",
+            sid="ZTF",
+            aid=oids[non_det["oid"]],
+            oid=non_det["oid"],
+            mjd=non_det["mjd"],
+            fid=FID[non_det["fid"]],
+            diffmaglim=non_det.get("diffmaglim", None),
+        )
+        mongo_non_detection.pop("_id")
+        mongo_non_detection.pop("extra_fields", None)
+        non_dets.append(mongo_non_detection)
+    return non_dets
+
+
+def parse_sql_forced_photometry(ztf_models: list, *, oids) -> list:
+    def format_as_detection(fp):
+        FID = {1: "g", 2: "r", 0: None, 12: "gr", 3: "i"}
+        fp["fid"] = FID[fp["fid"]]
+        fp["e_ra"] = 0
+        fp["e_dec"] = 0
+        fp["candid"] = fp.pop("_id")
+        fp["extra_fields"] = {
+            k: v
+            for k, v in fp["extra_fields"].items()
+            if not k.startswith("_")
+        }
+        # remove problematic fields
+        FIELDS_TO_REMOVE = [
+            "stellar",
+            "e_mag_corr",
+            "corrected",
+            "mag_corr",
+            "e_mag_corr_ext",
+            "dubious",
+        ]
+        for field in FIELDS_TO_REMOVE:
+            fp.pop(field, None)
+
+        return fp
+
+    parsed = [
+        {
+            **MongoForcedPhotometry(
+                **forced[0].__dict__,
+                aid=oids[forced[0].__dict__["oid"]],
+                sid="ZTF",
+                tid="ZTF",
+                candid=forced[0].__dict__["oid"]
+                + str(forced[0].__dict__["pid"]),
+            ),
+            "new": False,
+            "forced": True,
+        }
+        for forced in ztf_models
+    ]
+
+    return list(map(format_as_detection, parsed))

--- a/lightcurve-step/lightcurve_step/parser_sql.py
+++ b/lightcurve-step/lightcurve_step/parser_sql.py
@@ -54,7 +54,7 @@ def parse_sql_detection(ztf_models: list, *, oids) -> list:
                 parsed_det[field] = value
         parsed = MongoDetection(
             **parsed_det,
-            aid=oids[det["oid"]],
+            aid=det.get("aid", None),
             sid="ZTF",
             tid="ZTF",
             mag=det["magpsf"],
@@ -78,7 +78,6 @@ def parse_sql_detection(ztf_models: list, *, oids) -> list:
 
 
 def parse_sql_non_detection(ztf_models: list, *, oids) -> list:
-    FID = {1: "g", 2: "r", 0: None, 12: "gr", 3: "i"}
     non_dets = []
     for non_det in ztf_models:
         non_det = non_det[0].__dict__
@@ -86,10 +85,10 @@ def parse_sql_non_detection(ztf_models: list, *, oids) -> list:
             _id="jej",
             tid="ZTF",
             sid="ZTF",
-            aid=oids[non_det["oid"]],
+            aid=non_det.get("aid"),
             oid=non_det["oid"],
             mjd=non_det["mjd"],
-            fid=FID[non_det["fid"]],
+            fid=get_fid(non_det["fid"]),
             diffmaglim=non_det.get("diffmaglim", None),
         )
         mongo_non_detection.pop("_id")
@@ -100,8 +99,7 @@ def parse_sql_non_detection(ztf_models: list, *, oids) -> list:
 
 def parse_sql_forced_photometry(ztf_models: list, *, oids) -> list:
     def format_as_detection(fp):
-        FID = {1: "g", 2: "r", 0: None, 12: "gr", 3: "i"}
-        fp["fid"] = FID[fp["fid"]]
+        fp["fid"] = get_fid(fp["fid"])
         fp["e_ra"] = 0
         fp["e_dec"] = 0
         fp["candid"] = fp.pop("_id")
@@ -128,7 +126,7 @@ def parse_sql_forced_photometry(ztf_models: list, *, oids) -> list:
         {
             **MongoForcedPhotometry(
                 **forced[0].__dict__,
-                aid=oids[forced[0].__dict__["oid"]],
+                aid=forced[0].__dict__.get("aid"),
                 sid="ZTF",
                 tid="ZTF",
                 candid=forced[0].__dict__["oid"]

--- a/lightcurve-step/lightcurve_step/parser_utils.py
+++ b/lightcurve-step/lightcurve_step/parser_utils.py
@@ -1,3 +1,6 @@
 def get_fid(fid_as_int: int):
     fid = {1: "g", 2: "r", 0: None, 12: "gr", 3: "i"}
-    return fid[fid_as_int]
+    try:
+        return fid[fid_as_int]
+    except KeyError:
+        return fid_as_int

--- a/lightcurve-step/lightcurve_step/parser_utils.py
+++ b/lightcurve-step/lightcurve_step/parser_utils.py
@@ -1,0 +1,3 @@
+def get_fid(fid_as_int: int):
+    fid = {1: "g", 2: "r", 0: None, 12: "gr", 3: "i"}
+    return fid[fid_as_int]

--- a/lightcurve-step/lightcurve_step/step.py
+++ b/lightcurve-step/lightcurve_step/step.py
@@ -40,27 +40,21 @@ class LightcurveStep(GenericStep):
         self.db_mongo = db_mongo
         self.db_sql = db_sql
         self.logger = logging.getLogger("alerce.LightcurveStep")
-        self.set_producer_key_field("aid")
+        self.set_producer_key_field("oid")
 
     def pre_execute(self, messages: List[dict]) -> dict:
-        aids, detections, non_detections, oids = set(), [], [], {}
+        detections, non_detections, oids = [], [], set()
         last_mjds = {}
         candids = {}
         for msg in messages:
-            aid = msg["aid"]
-            if aid not in candids:
-                candids[aid] = []
-            candids[aid].append(str(msg["candid"]))
-            oids.update(
-                {
-                    det["oid"]: aid
-                    for det in msg["detections"]
-                    if det["sid"].lower() == "ztf"
-                }
-            )
-            aids.add(aid)
-            last_mjds[aid] = max(
-                last_mjds.get(aid, 0), msg["detections"][0]["mjd"]
+            print(msg)
+            oid = msg["oid"]
+            oids.add(oid)
+            if oid not in candids:
+                candids[oid] = []
+            candids[oid].append(str(msg["candid"]))
+            last_mjds[oid] = max(
+                last_mjds.get(oid, 0), msg["detections"][0]["mjd"]
             )
             detections.extend(
                 [det | {"new": True} for det in msg["detections"]]
@@ -70,25 +64,24 @@ class LightcurveStep(GenericStep):
         logger = logging.getLogger("alerce.LightcurveStep")
         logger.debug(f"Received {len(detections)} detections from messages")
         return {
-            "aids": list(aids),
+            "oids": list(oids),
             "candids": candids,
-            "oids": oids,
             "last_mjds": last_mjds,
             "detections": detections,
             "non_detections": non_detections,
         }
 
     def execute(self, messages: dict) -> dict:
-        """Queries the database for all detections and non-detections for each AID and removes duplicates"""
+        """Queries the database for all detections and non-detections for each OID and removes duplicates"""
 
         db_mongo_detections = _get_mongo_detections(
-            messages["aids"], self.db_mongo, parse_mongo_detection
+            messages["oids"], self.db_mongo, parse_mongo_detection
         )
         db_mongo_non_detections = _get_mongo_non_detections(
-            messages["aids"], self.db_mongo, parse_mongo_non_detection
+            messages["oids"], self.db_mongo, parse_mongo_non_detection
         )
         db_mongo_forced_photometries = _get_mongo_forced_photometries(
-            messages["aids"],
+            messages["oids"],
             self.db_mongo,
             parse_mongo_forced_photometry,
         )
@@ -116,18 +109,15 @@ class LightcurveStep(GenericStep):
         self.logger.debug(f"Retrieved {detections.shape[0]} detections")
         detections["candid"] = detections["candid"].astype(str)
         detections["parent_candid"] = detections["parent_candid"].astype(str)
-        detections["has_aid"] = (
-            detections["aid"] != "" and detections["aid"].notnull()
-        )
 
         # has_stamp true will be on top
         # new true will be on top
         # so this will drop alerts coming from the database if they are also in the stream
         detections = detections.sort_values(
-            ["has_stamp", "new", "has_aid"], ascending=[False, False, True]
+            ["has_stamp", "new"], ascending=[False, False]
         ).drop_duplicates("candid", keep="first")
 
-        non_detections = non_detections.drop_duplicates(["aid", "fid", "mjd"])
+        non_detections = non_detections.drop_duplicates(["oid", "fid", "mjd"])
         self.logger.debug(
             f"Obtained {len(detections[detections['new']])} new detections"
         )
@@ -148,17 +138,17 @@ class LightcurveStep(GenericStep):
             ef["diaObject"] = pickle.dumps(ef["diaObject"])
             return ef
 
-        detections = result["detections"].replace(np.nan, None).groupby("aid")
+        detections = result["detections"].replace(np.nan, None).groupby("oid")
         try:  # At least one non-detection
             non_detections = (
-                result["non_detections"].replace(np.nan, None).groupby("aid")
+                result["non_detections"].replace(np.nan, None).groupby("oid")
             )
         except KeyError:  # Handle empty non-detections
-            non_detections = pd.DataFrame(columns=["aid"]).groupby("aid")
+            non_detections = pd.DataFrame(columns=["oid"]).groupby("oid")
         output = []
-        for aid, dets in detections:
+        for oid, dets in detections:
             try:
-                nd = non_detections.get_group(aid).to_dict("records")
+                nd = non_detections.get_group(oid).to_dict("records")
             except KeyError:
                 nd = []
             dets["extra_fields"] = dets["extra_fields"].apply(
@@ -166,16 +156,15 @@ class LightcurveStep(GenericStep):
             )
             if not self.config["FEATURE_FLAGS"].get("SKIP_MJD_FILTER", False):
                 mjds = result["last_mjds"]
-                dets = dets[dets["mjd"] <= mjds[aid]]
+                dets = dets[dets["mjd"] <= mjds[oid]]
             detections_list = dets.to_dict("records")
 
             output.append(
                 {
-                    "aid": aid,
-                    "candid": result["candids"][aid],
+                    "oid": oid,
+                    "candid": result["candids"][oid],
                     "detections": detections_list,
                     "non_detections": nd,
                 }
             )
-        self.candid_found = False
         return output

--- a/lightcurve-step/lightcurve_step/step.py
+++ b/lightcurve-step/lightcurve_step/step.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pickle
 from typing import List
 from apf.core.step import GenericStep
+from apf.consumers import KafkaConsumer
 from .database_mongo import (
     DatabaseConnection,
     _get_mongo_non_detections,
@@ -168,3 +169,11 @@ class LightcurveStep(GenericStep):
                 }
             )
         return output
+
+    def tear_down(self):
+        self.db_mongo.client.close()
+        if isinstance(self.consumer, KafkaConsumer):
+            self.consumer.teardown()
+        else:
+            self.consumer.__del__()
+        self.producer.__del__()

--- a/lightcurve-step/poetry.lock
+++ b/lightcurve-step/poetry.lock
@@ -344,7 +344,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "db-plugins"
-version = "6.1.1a47"
+version = "6.1.1a61"
 description = "ALeRCE database plugins."
 optional = false
 python-versions = ">=3.7, <3.12"

--- a/lightcurve-step/pyproject.toml
+++ b/lightcurve-step/pyproject.toml
@@ -24,7 +24,7 @@ pytest-cov = "^4.1.0"
 test-utils = { path = "../libs/test_utils", develop = true }
 
 [tool.black]
-line-length = 88
+line-length = 79
 
 [tool.pytest.ini_options]
 addopts = "-x --cov lightcurve_step --cov-report xml"

--- a/lightcurve-step/tests/integration/conftest.py
+++ b/lightcurve-step/tests/integration/conftest.py
@@ -63,21 +63,20 @@ def env_variables():
 def produce_messages(kafka_service):
     topic_to_delete = ""
 
-    def _produce(topic: str, nmessages: int, detections: list = [], aids=[]):
+    def _produce(topic: str, nmessages: int, detections: list = [], oids=[]):
         nonlocal topic_to_delete
         topic_to_delete = topic
-        schema = load_schema("../schemas/prv_candidate_step/output.avsc")
+        schema_path = "../schemas/prv_candidate_step/output.avsc"
         producer = KafkaProducer(
             {
                 "PARAMS": {"bootstrap.servers": "localhost:9092"},
                 "TOPIC": topic,
-                "SCHEMA_PATH": os.path.join(
-                    os.path.dirname(__file__), "input_schema.avsc"
-                ),
+                "SCHEMA_PATH": schema_path,
             }
         )
-        messages = generate_message(schema, nmessages, detections, aids)
-        producer.set_key_field("aid")
+        schema = load_schema(schema_path)
+        messages = generate_message(schema, nmessages, detections, oids)
+        producer.set_key_field("oid")
 
         for message in messages:
             producer.produce(message)

--- a/lightcurve-step/tests/integration/conftest.py
+++ b/lightcurve-step/tests/integration/conftest.py
@@ -81,6 +81,7 @@ def produce_messages(kafka_service):
         for message in messages:
             producer.produce(message)
         producer.producer.flush()
+        del producer
 
     yield _produce
     admin_client = AdminClient({"bootstrap.servers": "localhost:9092"})

--- a/lightcurve-step/tests/integration/conftest.py
+++ b/lightcurve-step/tests/integration/conftest.py
@@ -1,11 +1,18 @@
 import os
 import pytest
 from apf.producers import KafkaProducer
+from confluent_kafka.admin import AdminClient
 import uuid
 from fastavro.schema import load_schema
-from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import insert
 from db_plugins.db.sql._connection import PsqlDatabase
 from db_plugins.db.mongo._connection import MongoConnection
+from db_plugins.db.sql.models import (
+    Object,
+    Detection,
+    NonDetection,
+    ForcedPhotometry,
+)
 from .utils import generate_message
 
 
@@ -54,8 +61,12 @@ def env_variables():
 
 @pytest.fixture()
 def produce_messages(kafka_service):
-    def _produce(topic: str):
-        schema = load_schema("tests/integration/input_schema.avsc")
+    topic_to_delete = ""
+
+    def _produce(topic: str, nmessages: int, detections: list = [], aids=[]):
+        nonlocal topic_to_delete
+        topic_to_delete = topic
+        schema = load_schema("../schemas/prv_candidate_step/output.avsc")
         producer = KafkaProducer(
             {
                 "PARAMS": {"bootstrap.servers": "localhost:9092"},
@@ -65,124 +76,219 @@ def produce_messages(kafka_service):
                 ),
             }
         )
-        messages = generate_message(schema, 10)
+        messages = generate_message(schema, nmessages, detections, aids)
         producer.set_key_field("aid")
 
         for message in messages:
             producer.produce(message)
         producer.producer.flush()
 
-    return _produce
+    yield _produce
+    admin_client = AdminClient({"bootstrap.servers": "localhost:9092"})
+    admin_client.delete_topics(
+        [topic_to_delete], operation_timeout=30, request_timeout=30
+    )[topic_to_delete].result()
 
 
-def populate_mongo(mongo_database):
-    mongo_database["detection"].insert_one(
-        {
-            "candid": 987654321,
-            "oid": "ZTF000llmn",
-            "tid": "ztf",
-            "sid": "ztf",
-            "aid": "AL00XYZ00",
-            "pid": 1,
-            "mjd": 1,
-            "fid": 1,
-            "isdiffpos": -1,
-            "ra": 45,
-            "dec": 45,
-            "e_ra": 0.1,
-            "e_dec": 0.1,
-            "mag": 23.1,
-            "e_mag": 0.9,
-            "corrected": False,
-            "dubious": False,
-            "has_stamp": False,
-        }
-    )
-    mongo_database["object"].insert_one(
-        {
-            "aid": "AL00XYZ00",
-            "oid": "ZTF000llmn",
-            "ndet": 1,
-            "firstmjd": 50001,
-            "lastmjd": 50001,
-            "deltajd": 0,
-            "meanra": 45,
-            "meandec": 45,
-            "sigmara": 0.1,
-            "sigmadec": 0.1,
-        }
-    )
-    mongo_database["non_detection"].insert_one(
-        {
-            "candid": 987654321,
-            "oid": "ZTF000llmn",
-            "fid": 1,
-            "mjd": 55000,
-            "diffmaglim": 42.00,
-            "aid": "AL00XYZ00",
-            "tid": "ztf",
-            "sid": "ztf",
-        }
-    )
-    mongo_database["forced_photometry"].insert_one(
-        {
-            "_id": "ZTF000llmn_9182734",
-            "oid": "ZTF000llmn",
-            "mjd": 55500,
-            "pid": 9182734,
-            "mag": 21,
-            "e_mag": 0.1,
-            "fid": 1,
-            "ra": 45.0,
-            "dec": 45.0,
-            "isdiffpos": 1,
-            "corrected": False,
-            "dubious": False,
-            "has_stamp": False,
-            "aid": "AL00XYZ00",
-            "tid": "ztf",
-            "sid": "ztf",
-        }
-    )
+@pytest.fixture
+def insert_object():
+    def _populate(
+        object: dict,
+        *,
+        sql: PsqlDatabase = None,
+        mongo: MongoConnection = None,
+    ):
+        if sql:
+            with sql.session() as session:
+                statement = (
+                    insert(Object)
+                    .values(
+                        oid=object["oid"],
+                        ndet=1,
+                        firstmjd=50001,
+                        g_r_max=1.0,
+                        g_r_mean_corr=0.9,
+                        meanra=45,
+                        meandec=45,
+                        step_id_corr="v1",
+                        lastmjd=50001,
+                        deltajd=0,
+                        ncovhist=1,
+                        ndethist=1,
+                        corrected=False,
+                        stellar=False,
+                    )
+                    .on_conflict_do_nothing()
+                )
+                session.execute(statement)
+                session.commit()
+        if mongo:
+            mongo.database["object"].insert_one(
+                {
+                    # "aid": "AL00XYZ00",
+                    "aid": object["aid"],
+                    "oid": object["oid"],
+                    "ndet": 1,
+                    "firstmjd": 50001,
+                    "lastmjd": 50001,
+                    "deltajd": 0,
+                    "meanra": 45,
+                    "meandec": 45,
+                    "sigmara": 0.1,
+                    "sigmadec": 0.1,
+                }
+            )
+
+    return _populate
 
 
-def populate_sql(conn: PsqlDatabase):
-    with conn.session() as session:
-        session.execute(
-            text(
-                """
-            INSERT INTO object(oid, ndet, firstmjd, g_r_max, g_r_mean_corr, meanra, meandec, step_id_corr, \
-                lastmjd, deltajd, ncovhist, ndethist, corrected, stellar)
-                VALUES ('ZTF000llmn', 1, 50001, 1.0, 0.9, 45, 45, 'v1', 50001, 0, 1, 1, false, false) ON CONFLICT DO NOTHING
-        """
+@pytest.fixture
+def insert_detection():
+    def _populate(
+        detection: dict,
+        *,
+        sql: PsqlDatabase = None,
+        mongo: MongoConnection = None,
+    ):
+        if sql:
+            with sql.session() as session:
+                statement = (
+                    insert(Detection)
+                    .values(
+                        candid=detection["candid"],
+                        oid=detection["oid"],
+                        mjd=1,
+                        fid=1,
+                        pid=1,
+                        diffmaglim=0.8,
+                        isdiffpos=-1,
+                        ra=45,
+                        dec=45,
+                        magpsf=23.1,
+                        sigmapsf=0.9,
+                        corrected=False,
+                        dubious=False,
+                        has_stamp=detection["has_stamp"],
+                        step_id_corr="step",
+                    )
+                    .on_conflict_do_nothing()
+                )
+                session.execute(statement)
+                session.commit()
+        if mongo:
+            mongo.database["detection"].insert_one(
+                {
+                    "_id": detection["candid"],
+                    "candid": detection["candid"],
+                    "oid": detection["oid"],
+                    "tid": "ztf",
+                    "sid": "ztf",
+                    "aid": "AL00XYZ00",
+                    "pid": 1,
+                    "mjd": 1,
+                    "fid": 1,
+                    "isdiffpos": -1,
+                    "ra": 45,
+                    "dec": 45,
+                    "e_ra": 0.1,
+                    "e_dec": 0.1,
+                    "mag": 23.1,
+                    "e_mag": 0.9,
+                    "corrected": False,
+                    "dubious": False,
+                    "has_stamp": detection["has_stamp"],
+                    "extra_fields": {},
+                }
             )
-        )
-        session.execute(
-            text(
-                """
-            INSERT INTO detection(candid, oid, mjd, fid, pid, diffmaglim, isdiffpos, \
-            ra, dec, magpsf, sigmapsf, corrected, dubious, has_stamp, step_id_corr) 
-            VALUES (987654321, 'ZTF000llmn', 1, 1, 1, 0.8, -1, 45, 45, 23.1, 0.9, \
-                    false, false, false, 'step')
-        """
+
+    return _populate
+
+
+@pytest.fixture
+def insert_non_detection():
+    def _populate(
+        non_detection: dict,
+        *,
+        sql: PsqlDatabase = None,
+        mongo: MongoConnection = None,
+    ):
+        if sql:
+            with sql.session() as session:
+                statement = insert(NonDetection).values(
+                    oid=non_detection["oid"],
+                    fid=1,
+                    mjd=55000,
+                    diffmaglim=42.00,
+                )
+                session.execute(statement)
+                session.commit()
+        if mongo:
+            mongo.database["non_detection"].insert_one(
+                {
+                    "candid": 987654321,
+                    "oid": "ZTF000llmn",
+                    "fid": 1,
+                    "mjd": 55000,
+                    "diffmaglim": 42.00,
+                    "aid": "AL00XYZ00",
+                    "tid": "ztf",
+                    "sid": "ztf",
+                }
             )
-        )
-        session.execute(
-            text(
-                """
-            INSERT INTO non_detection(oid, fid, mjd, diffmaglim) VALUES ('ZTF000llmn', 1, 55000, 42.00)
-            """
+
+    return _populate
+
+
+@pytest.fixture
+def insert_forced_photometry():
+    def _populate(
+        forced_photometry: dict,
+        *,
+        sql: PsqlDatabase = None,
+        mongo: MongoConnection = None,
+    ):
+        if sql:
+            with sql.session() as session:
+                statement = insert(ForcedPhotometry).values(
+                    oid=forced_photometry["oid"],
+                    mjd=1,
+                    pid=1,
+                    mag=21,
+                    e_mag=0.1,
+                    fid=1,
+                    ra=45,
+                    dec=45,
+                    isdiffpos=1,
+                    corrected=False,
+                    dubious=False,
+                    has_stamp=False,
+                )
+                session.execute(statement)
+                session.commit()
+        if mongo:
+            mongo.database["forced_photometry"].insert_one(
+                {
+                    "_id": "%s%s"
+                    % (forced_photometry["oid"], forced_photometry["pid"]),
+                    "oid": forced_photometry["oid"],
+                    "mjd": 55500,
+                    "pid": 9182734,
+                    "mag": 21,
+                    "e_mag": 0.1,
+                    "fid": 1,
+                    "ra": 45.0,
+                    "dec": 45.0,
+                    "isdiffpos": 1,
+                    "corrected": False,
+                    "dubious": False,
+                    "has_stamp": False,
+                    "aid": "AL00XYZ00",
+                    "tid": "ztf",
+                    "sid": "ztf",
+                }
             )
-        )
-        session.execute(
-            text(
-                """
-            INSERT INTO forced_photometry(oid, mjd, pid, mag, e_mag, fid, ra, dec, isdiffpos, corrected, dubious, has_stamp)
-            VALUES ('ZTF000llmn', 55500, 9182734, 21, 0.1, 1, 45.0, 45.0, 1, false, false, false)
-            """
-            )
-        )
-        session.commit()
+
+    return _populate
 
 
 @pytest.fixture()
@@ -196,7 +302,6 @@ def psql_conn(psql_service):
     }
     psql_conn = PsqlDatabase(config)
     psql_conn.create_db()
-    populate_sql(psql_conn)
     yield psql_conn
     psql_conn.drop_db()
 
@@ -213,6 +318,5 @@ def mongo_conn(mongo_service):
     }
     conn = MongoConnection(config)
     conn.create_db()
-    populate_mongo(conn.database)
     yield conn
     conn.drop_db()

--- a/lightcurve-step/tests/integration/test_database_sql.py
+++ b/lightcurve-step/tests/integration/test_database_sql.py
@@ -65,5 +65,5 @@ def test_get_detections(psql_conn: PsqlDatabase):
         session.commit()
         session.add(det)
         session.commit()
-    detections = _get_sql_detections({"1": "aid"}, psql_conn)
+    detections = _get_sql_detections(["1"], psql_conn)
     assert len(detections) == 1

--- a/lightcurve-step/tests/integration/test_prv_detections.py
+++ b/lightcurve-step/tests/integration/test_prv_detections.py
@@ -1,0 +1,460 @@
+"""
+This test file aims to check if the step keeps detections from the stream rather than from
+the database. If a detection is in the stream and also in the database there are 5 options.
+
+1. The detection is an alert (has stamp) and is being inserted for the first time
+        It should then be kept as it is
+2. The detection is an alert and it is being reprocessed
+        The one from the database should be discarded
+3. The detection is a prv detection (does not have stamp) and is being inserted for the first time
+        It should then be kept as it is
+4. The detection is an alert but came as a prv detection (does not have stamp)
+        The one from the database should be kept
+5. The detection is a prv detection and it is being reprocessed
+        The one from the database should be discarded
+"""
+
+from unittest import mock
+from .utils.mock_secret import mock_get_secret
+
+
+@mock.patch("credentials.get_secret")
+def test_alert_first_time(
+    mock_credentials,
+    produce_messages,
+    mongo_service,
+    env_variables,
+    psql_conn,
+    mongo_conn,
+    kafka_consumer,
+    insert_object,
+    insert_non_detection,
+    insert_forced_photometry,
+    insert_detection,
+):
+    from scripts.run_step import step_creator
+
+    insert_object(
+        {"oid": "ZTF000llmn", "aid": "AL00XYZ00"},
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+    insert_detection(
+        {
+            "oid": "ZTF000llmn",
+            "aid": "AL00XYZ00",
+            "candid": "123",
+            "has_stamp": True,
+        },
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+
+    mock_credentials.side_effect = mock_get_secret
+    detections = [
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "456",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": True,
+            "forced": False,
+            "extra_fields": {},
+        },
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "ZTF000llmn555",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": False,
+            "forced": True,
+            "extra_fields": {},
+        },
+    ]
+    produce_messages(
+        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+    )
+    step_creator().start()
+
+    consumer = kafka_consumer(["lightcurve"])
+    messages = list(consumer.consume())
+    assert len(messages) == 1
+    msg = messages[0]
+    detections = msg["detections"]
+    assert len(detections) == 3
+    assert all([det["new"] for det in detections if det["candid"] != "123"])
+    assert not all(
+        [det["new"] for det in detections if det["candid"] == "123"]
+    )
+
+
+@mock.patch("credentials.get_secret")
+def test_alert_reprocess(
+    mock_credentials,
+    produce_messages,
+    mongo_service,
+    env_variables,
+    psql_conn,
+    mongo_conn,
+    kafka_consumer,
+    insert_object,
+    insert_non_detection,
+    insert_forced_photometry,
+    insert_detection,
+):
+    from scripts.run_step import step_creator
+
+    insert_object(
+        {"oid": "ZTF000llmn", "aid": "AL00XYZ00"},
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+    insert_detection(
+        {
+            "oid": "ZTF000llmn",
+            "aid": "AL00XYZ00",
+            "candid": "123",
+            "has_stamp": True,
+        },
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+
+    mock_credentials.side_effect = mock_get_secret
+    detections = [
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "123",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": True,
+            "forced": False,
+            "extra_fields": {},
+        },
+    ]
+    produce_messages(
+        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+    )
+    step_creator().start()
+
+    consumer = kafka_consumer(["lightcurve"])
+    messages = list(consumer.consume())
+    assert len(messages) == 1
+    msg = messages[0]
+    detections = msg["detections"]
+    assert len(detections) == 1
+    det = detections[0]
+    assert det["candid"] == "123"
+    assert det["has_stamp"]
+    assert det["new"]
+
+
+@mock.patch("credentials.get_secret")
+def test_alert_prv_detection(
+    mock_credentials,
+    produce_messages,
+    mongo_service,
+    env_variables,
+    psql_conn,
+    mongo_conn,
+    kafka_consumer,
+    insert_object,
+    insert_non_detection,
+    insert_forced_photometry,
+    insert_detection,
+):
+    from scripts.run_step import step_creator
+
+    mock_credentials.side_effect = mock_get_secret
+    detections = [
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "123",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": True,
+            "forced": False,
+            "extra_fields": {},
+        },
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "456",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": False,
+            "forced": False,
+            "extra_fields": {},
+        },
+    ]
+    produce_messages(
+        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+    )
+    step_creator().start()
+
+    consumer = kafka_consumer(["lightcurve"])
+    messages = list(consumer.consume())
+    assert len(messages) == 1
+    msg = messages[0]
+    detections = msg["detections"]
+    assert len(detections) == 2
+    det = detections[0]
+    assert det["candid"] == "123"
+    assert det["has_stamp"]
+    det = detections[1]
+    assert det["candid"] == "456"
+    assert not det["has_stamp"]
+
+
+@mock.patch("credentials.get_secret")
+def test_alert_prv_detection_alert(
+    mock_credentials,
+    produce_messages,
+    mongo_service,
+    env_variables,
+    psql_conn,
+    mongo_conn,
+    kafka_consumer,
+    insert_object,
+    insert_non_detection,
+    insert_forced_photometry,
+    insert_detection,
+):
+    from scripts.run_step import step_creator
+
+    insert_object(
+        {"oid": "ZTF000llmn", "aid": "AL00XYZ00"},
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+    insert_detection(
+        {
+            "oid": "ZTF000llmn",
+            "aid": "AL00XYZ00",
+            "candid": "123",
+            "has_stamp": True,
+        },
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+
+    mock_credentials.side_effect = mock_get_secret
+    detections = [
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "123",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": False,
+            "forced": False,
+            "extra_fields": {},
+        },
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "ZTF000llmn555",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": False,
+            "forced": True,
+            "extra_fields": {},
+        },
+    ]
+    produce_messages(
+        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+    )
+    step_creator().start()
+
+    consumer = kafka_consumer(["lightcurve"])
+    messages = list(consumer.consume())
+    assert len(messages) == 1
+    msg = messages[0]
+    detections = msg["detections"]
+    assert len(detections) == 2
+    det = detections[0]
+    assert det["candid"] == "123"
+    assert det["has_stamp"]
+    det = detections[1]
+    assert det["candid"] == "ZTF000llmn555"
+    assert not det["has_stamp"]
+    assert det["forced"]
+
+
+@mock.patch("credentials.get_secret")
+def test_alert_prv_detection_alert_reprocess(
+    mock_credentials,
+    produce_messages,
+    mongo_service,
+    env_variables,
+    psql_conn,
+    mongo_conn,
+    kafka_consumer,
+    insert_object,
+    insert_non_detection,
+    insert_forced_photometry,
+    insert_detection,
+):
+    from scripts.run_step import step_creator
+
+    insert_object(
+        {"oid": "ZTF000llmn", "aid": "AL00XYZ00"},
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+    insert_detection(
+        {
+            "oid": "ZTF000llmn",
+            "aid": "AL00XYZ00",
+            "candid": "123",
+            "has_stamp": True,
+        },
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+    insert_detection(
+        {
+            "oid": "ZTF000llmn",
+            "aid": "AL00XYZ00",
+            "candid": "456",
+            "has_stamp": False,
+        },
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+
+    mock_credentials.side_effect = mock_get_secret
+    detections = [
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "123",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": True,
+            "forced": False,
+            "extra_fields": {},
+        },
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "456",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": False,
+            "forced": False,
+            "extra_fields": {},
+        },
+    ]
+    produce_messages(
+        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+    )
+    step_creator().start()
+
+    consumer = kafka_consumer(["lightcurve"])
+    messages = list(consumer.consume())
+    assert len(messages) == 1
+    msg = messages[0]
+    detections = msg["detections"]
+    assert len(detections) == 2
+    det = detections[0]
+    assert det["candid"] == "123"
+    assert det["has_stamp"]
+    det = detections[1]
+    assert det["candid"] == "456"
+    assert not det["has_stamp"]
+    assert not det["forced"]

--- a/lightcurve-step/tests/integration/test_prv_detections.py
+++ b/lightcurve-step/tests/integration/test_prv_detections.py
@@ -94,7 +94,7 @@ def test_alert_first_time(
         },
     ]
     produce_messages(
-        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+        "correction", 1, detections=detections, oids=["ZTF000llmn"]
     )
     step_creator().start()
 
@@ -166,7 +166,7 @@ def test_alert_reprocess(
         },
     ]
     produce_messages(
-        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+        "correction", 1, detections=detections, oids=["ZTF000llmn"]
     )
     step_creator().start()
 
@@ -242,7 +242,7 @@ def test_alert_prv_detection(
         },
     ]
     produce_messages(
-        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+        "correction", 1, detections=detections, oids=["ZTF000llmn"]
     )
     step_creator().start()
 
@@ -336,7 +336,7 @@ def test_alert_prv_detection_alert(
         },
     ]
     produce_messages(
-        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+        "correction", 1, detections=detections, oids=["ZTF000llmn"]
     )
     step_creator().start()
 
@@ -441,7 +441,7 @@ def test_alert_prv_detection_alert_reprocess(
         },
     ]
     produce_messages(
-        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+        "correction", 1, detections=detections, oids=["ZTF000llmn"]
     )
     step_creator().start()
 

--- a/lightcurve-step/tests/integration/test_run_step.py
+++ b/lightcurve-step/tests/integration/test_run_step.py
@@ -55,7 +55,7 @@ def test_step_start(
         },
     ]
     produce_messages(
-        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+        "correction", 1, detections=detections, oids=["ZTF000llmn"]
     )
     step_creator().start()
 

--- a/lightcurve-step/tests/integration/test_run_step.py
+++ b/lightcurve-step/tests/integration/test_run_step.py
@@ -1,32 +1,5 @@
 from unittest import mock
-import json
-import os
-
-
-def mock_get_secret(secret_name):
-    if secret_name == "sql_secret":
-        return json.dumps(
-            {
-                "HOST": "localhost",
-                "USER": "postgres",
-                "PASSWORD": "postgres",
-                "PORT": 5432,
-                "DB_NAME": "postgres",
-            }
-        )
-    elif secret_name == "mongo_secret":
-        return json.dumps(
-            {
-                "HOST": "localhost",
-                "USERNAME": "test_user",
-                "PASSWORD": "test_password",
-                "PORT": 27017,
-                "DATABASE": "test_db",
-                "AUTH_SOURCE": "test_db",
-            }
-        )
-    else:
-        raise ValueError("Unknown secret name")
+from .utils.mock_secret import mock_get_secret
 
 
 @mock.patch("credentials.get_secret")
@@ -38,68 +11,61 @@ def test_step_start(
     psql_conn,
     mongo_conn,
     kafka_consumer,
+    insert_object,
+    insert_detection,
 ):
     from scripts.run_step import step_creator
 
     mock_credentials.side_effect = mock_get_secret
-    produce_messages("correction")
+    insert_object(
+        {"oid": "ZTF000llmn", "aid": "AL00XYZ00"},
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+    insert_detection(
+        {
+            "oid": "ZTF000llmn",
+            "aid": "AL00XYZ00",
+            "candid": "123",
+            "has_stamp": True,
+        },
+        sql=psql_conn,
+        mongo=mongo_conn,
+    )
+    detections = [
+        {
+            "aid": "AL00XYZ00",
+            "oid": "ZTF000llmn",
+            "sid": "ztf",
+            "tid": "ztf",
+            "pid": 555,
+            "fid": "g",
+            "candid": "456",
+            "mjd": 55000,
+            "ra": 45,
+            "e_ra": 0.1,
+            "dec": 45,
+            "e_dec": 0.1,
+            "mag": 23.1,
+            "e_mag": 0.9,
+            "isdiffpos": 1,
+            "has_stamp": True,
+            "forced": False,
+            "extra_fields": {},
+        },
+    ]
+    produce_messages(
+        "correction", 1, detections=detections, aids=["AL00XYZ00"]
+    )
     step_creator().start()
 
     consumer = kafka_consumer(["lightcurve"])
     messages = list(consumer.consume())
-    assert len(messages) == 10
+    assert len(messages) == 1
     for msg in messages:
         detections = msg["detections"]
         oids = set(map(lambda x: x["oid"], msg["detections"]))
         assert len(oids) == 1
-        if oids.pop() == "ZTF000llmn":
-            assert len(detections) == 12  # 10 from the input + 2 from the db
-        else:
-            assert len(detections) == 10  # 10 from the input only
+        assert len(detections) == 2
         candids_are_string = list(map(lambda x: type(x) == str, msg["candid"]))
         assert all(candids_are_string)
-
-
-def test_step_with_explicit_db_config(
-    produce_messages,
-    mongo_service,
-    psql_conn,
-    kafka_consumer,
-):
-    produce_messages("correction1")
-    envcopy = os.environ.copy()
-    env_variables_dict = {
-        "PRODUCER_SCHEMA_PATH": "../schemas/lightcurve_step/output.avsc",
-        "CONSUMER_SCHEMA_PATH": "",
-        "METRICS_SCHEMA_PATH": "../schemas/lightcurve_step//metrics.json",
-        "SCRIBE_SCHEMA_PATH": "../schemas/scribe.avsc",
-        "CONSUMER_SERVER": "localhost:9092",
-        "CONSUMER_TOPICS": "correction1",
-        "CONSUMER_GROUP_ID": "with_explicit_db_config",
-        "METRICS_SERVER": "localhost:9092",
-        "PRODUCER_SERVER": "localhost:9092",
-        "PRODUCER_TOPIC": "lightcurve1",
-        "ENABLE_PARTITION_EOF": "True",
-        "CONSUME_MESSAGES": "10",
-        "MONGO_HOST": "localhost",
-        "MONGO_USERNAME": "test_user",
-        "MONGO_PASSWORD": "test_password",
-        "MONGO_PORT": "27017",
-        "MONGO_DATABASE": "test_db",
-        "MONGO_AUTH_SOURCE": "test_db",
-        "PSQL_HOST": "localhost",
-        "PSQL_USERNAME": "postgres",
-        "PSQL_PASSWORD": "postgres",
-        "PSQL_PORT": "5432",
-        "PSQL_DATABASE": "postgres",
-    }
-    for key in env_variables_dict:
-        os.environ[key] = env_variables_dict[key]
-
-    from scripts.run_step import step_creator
-
-    step_creator().start()
-
-    consumer = kafka_consumer(["lightcurve1"])
-    assert len(list(consumer.consume())) == 10
-    os.environ = envcopy

--- a/lightcurve-step/tests/integration/utils/generate_message.py
+++ b/lightcurve-step/tests/integration/utils/generate_message.py
@@ -4,32 +4,28 @@ import random
 random.seed(42)
 
 
-def generate_message(schema, n=10):
+def get_parent_candid(index, candids):
+    if random.random() < 0.5:
+        try:
+            return candids[index]
+        except IndexError:
+            return None
+
+
+def get_candid(index, candids):
+    try:
+        return candids[index]
+    except IndexError:
+        return random.randint(1000000, 10000000)
+
+
+def generate_message(schema, n=10, detections=[], aids=[]):
     messages = generate_many(schema, n)
     parsed_msgs = []
-    n_ztf, n_atlas = 0, 0
-    # lets say 70% ztf, 30% atlas
     for i, message in enumerate(messages):
-        aid = f"AL{i:02}XYZ{n_ztf:02}{n_atlas:02}"
+        aid = aids[i]
         message["aid"] = aid
-        dice = random.random()
-        if dice < 0.7:
-            sid, tid = "ZTF", "ZTF"
-            oid = f"ZTF{n_ztf:03}llmn"
-            n_ztf += 1
-        else:
-            sid, tid = "ATLAS", "ATLAS-01a"
-            oid = f"ATLAS{n_atlas:03}kxnmas"
-            n_atlas += 1
-        for detection in message["detections"]:
-            detection["sid"] = sid
-            detection["tid"] = tid
-            detection["oid"] = oid
-            detection["aid"] = aid
-            detection["candid"] = random.randint(1000000, 10000000)
-            detection["fid"] = "g"
-            detection["parent_candid"] = random.randint(1000000, 10000000)
-
+        message["detections"] = detections
         parsed_msgs.append(message)
 
     return parsed_msgs

--- a/lightcurve-step/tests/integration/utils/generate_message.py
+++ b/lightcurve-step/tests/integration/utils/generate_message.py
@@ -4,27 +4,12 @@ import random
 random.seed(42)
 
 
-def get_parent_candid(index, candids):
-    if random.random() < 0.5:
-        try:
-            return candids[index]
-        except IndexError:
-            return None
-
-
-def get_candid(index, candids):
-    try:
-        return candids[index]
-    except IndexError:
-        return random.randint(1000000, 10000000)
-
-
-def generate_message(schema, n=10, detections=[], aids=[]):
+def generate_message(schema, n=10, detections=[], oids=[]):
     messages = generate_many(schema, n)
     parsed_msgs = []
     for i, message in enumerate(messages):
-        aid = aids[i]
-        message["aid"] = aid
+        oid = oids[i]
+        message["oid"] = oid
         message["detections"] = detections
         parsed_msgs.append(message)
 

--- a/lightcurve-step/tests/integration/utils/mock_secret.py
+++ b/lightcurve-step/tests/integration/utils/mock_secret.py
@@ -1,0 +1,27 @@
+import json
+
+
+def mock_get_secret(secret_name):
+    if secret_name == "sql_secret":
+        return json.dumps(
+            {
+                "HOST": "localhost",
+                "USER": "postgres",
+                "PASSWORD": "postgres",
+                "PORT": 5432,
+                "DB_NAME": "postgres",
+            }
+        )
+    elif secret_name == "mongo_secret":
+        return json.dumps(
+            {
+                "HOST": "localhost",
+                "USERNAME": "test_user",
+                "PASSWORD": "test_password",
+                "PORT": 27017,
+                "DATABASE": "test_db",
+                "AUTH_SOURCE": "test_db",
+            }
+        )
+    else:
+        raise ValueError("Unknown secret name")

--- a/lightcurve-step/tests/unittest/test_step.py
+++ b/lightcurve-step/tests/unittest/test_step.py
@@ -3,6 +3,7 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 from lightcurve_step.step import LightcurveStep
 from settings import settings_creator
+import pickle
 
 
 def test_pre_execute_joins_detections_and_non_detections_and_adds_new_flag_to_detections(
@@ -10,7 +11,7 @@ def test_pre_execute_joins_detections_and_non_detections_and_adds_new_flag_to_de
 ):
     messages = [
         {
-            "aid": "aid1",
+            "oid": "oid1",
             "candid": "a",
             "detections": [
                 {
@@ -24,18 +25,18 @@ def test_pre_execute_joins_detections_and_non_detections_and_adds_new_flag_to_de
                 },
                 {
                     "aid": "aid1",
-                    "oid": "oid2",
+                    "oid": "oid1",
                     "sid": "ztf",
                     "candid": "b",
                     "mjd": 2,
-                    "has_stamp": True,
+                    "has_stamp": False,
                     "extra_fields": {},
                 },
             ],
-            "non_detections": [{"mjd": 1, "oid": "i", "fid": "g"}],
+            "non_detections": [{"mjd": 1, "oid": "oid1", "fid": "g"}],
         },
         {
-            "aid": "aid1",
+            "oid": "oid3",
             "candid": "c",
             "detections": [
                 {
@@ -47,42 +48,33 @@ def test_pre_execute_joins_detections_and_non_detections_and_adds_new_flag_to_de
                     "has_stamp": True,
                     "extra_fields": {},
                 },
-                {
-                    "aid": "aid1",
-                    "oid": "oid1",
-                    "sid": "ztf",
-                    "candid": "b",
-                    "mjd": 2,
-                    "has_stamp": True,
-                    "extra_fields": {},
-                },
             ],
-            "non_detections": [{"mjd": 1, "oid": "i", "fid": "g"}],
+            "non_detections": [{"mjd": 1, "oid": "oid3", "fid": "g"}],
         },
         {
-            "aid": "aid2",
-            "candid": "c",
+            "oid": "oid2",
+            "candid": "d",
             "detections": [
                 {
                     "aid": "aid2",
-                    "oid": "oid6",
+                    "oid": "oid2",
                     "sid": "ztf",
-                    "candid": "c",
+                    "candid": "d",
                     "mjd": 5,
                     "has_stamp": True,
                     "extra_fields": {},
                 },
                 {
                     "aid": "aid2",
-                    "oid": "oid5",
-                    "sid": "atlas",
-                    "candid": "b",
+                    "oid": "oid2",
+                    "sid": "ztf",
+                    "candid": "e",
                     "mjd": 4,
-                    "has_stamp": True,
+                    "has_stamp": False,
                     "extra_fields": {},
                 },
             ],
-            "non_detections": [{"mjd": 1, "oid": "i", "fid": "g"}],
+            "non_detections": [{"mjd": 1, "oid": "oid2", "fid": "g"}],
         },
     ]
 
@@ -90,15 +82,9 @@ def test_pre_execute_joins_detections_and_non_detections_and_adds_new_flag_to_de
         settings_creator(), mock.MagicMock(), mock.MagicMock()
     ).pre_execute(messages)
     expected = {
-        "aids": ["aid1", "aid2"],
-        "candids": {"aid1": ["a", "c"], "aid2": ["c"]},
-        "oids": {
-            "oid1": "aid1",
-            "oid2": "aid1",
-            "oid3": "aid1",
-            "oid6": "aid2",
-        },
-        "last_mjds": {"aid1": 4, "aid2": 5},
+        "oids": ["oid1", "oid2", "oid3"],
+        "candids": {"oid1": ["a"], "oid3": ["c"], "oid2": ["d"]},
+        "last_mjds": {"oid1": 3, "oid2": 5, "oid3": 4},
         "detections": [
             {
                 "aid": "aid1",
@@ -112,11 +98,11 @@ def test_pre_execute_joins_detections_and_non_detections_and_adds_new_flag_to_de
             },
             {
                 "aid": "aid1",
-                "oid": "oid2",
+                "oid": "oid1",
                 "sid": "ztf",
                 "candid": "b",
                 "mjd": 2,
-                "has_stamp": True,
+                "has_stamp": False,
                 "extra_fields": {},
                 "new": True,
             },
@@ -131,20 +117,10 @@ def test_pre_execute_joins_detections_and_non_detections_and_adds_new_flag_to_de
                 "new": True,
             },
             {
-                "aid": "aid1",
-                "oid": "oid1",
-                "sid": "ztf",
-                "candid": "b",
-                "mjd": 2,
-                "has_stamp": True,
-                "extra_fields": {},
-                "new": True,
-            },
-            {
                 "aid": "aid2",
-                "oid": "oid6",
+                "oid": "oid2",
                 "sid": "ztf",
-                "candid": "c",
+                "candid": "d",
                 "mjd": 5,
                 "has_stamp": True,
                 "extra_fields": {},
@@ -152,23 +128,23 @@ def test_pre_execute_joins_detections_and_non_detections_and_adds_new_flag_to_de
             },
             {
                 "aid": "aid2",
-                "oid": "oid5",
-                "sid": "atlas",
-                "candid": "b",
+                "oid": "oid2",
+                "sid": "ztf",
+                "candid": "e",
                 "mjd": 4,
-                "has_stamp": True,
+                "has_stamp": False,
                 "extra_fields": {},
                 "new": True,
             },
         ],
         "non_detections": [
-            {"mjd": 1, "oid": "i", "fid": "g"},
-            {"mjd": 1, "oid": "i", "fid": "g"},
-            {"mjd": 1, "oid": "i", "fid": "g"},
+            {"mjd": 1, "oid": "oid1", "fid": "g"},
+            {"mjd": 1, "oid": "oid3", "fid": "g"},
+            {"mjd": 1, "oid": "oid2", "fid": "g"},
         ],
     }
-    expected_aids = expected.pop("aids")
-    output_aids = output.pop("aids")
+    expected_aids = expected.pop("oids")
+    output_aids = output.pop("oids")
     assert set(expected_aids) == set(output_aids)
     assert output == expected
 
@@ -184,7 +160,7 @@ def test_execute_removes_duplicates_keeping_ones_with_stamps(
     step = LightcurveStep(settings_creator(), db_mongo, db_sql)
     mock_mongo.database["detection"].aggregate.return_value = [
         {
-            "aid": "aid2",
+            "aid": "aid1",
             "candid": "d",
             "oid": "ZTF123",
             "parent_candid": "p_d",
@@ -195,29 +171,17 @@ def test_execute_removes_duplicates_keeping_ones_with_stamps(
             "new": False,
             "extra_fields": {},
         },
-        {
-            "aid": "aid1",
-            "candid": 97923792234,
-            "parent_candid": "p_a",
-            "oid": "oidy",
-            "has_stamp": True,
-            "sid": "SURVEY",
-            "mjd": 1.0,
-            "fid": "g",
-            "new": False,
-            "extra_fields": {},
-        },
     ]
     mock_mongo.query.return_value.collection.find.return_value = []
 
     _get_sql_det.return_value = [
         {
-            "aid": "aid2",
+            "aid": "aid1",
             "oid": "ZTF123",
             "candid": "d",
             "parent_candid": "p_d",
             "has_stamp": True,
-            "sid": "SURVEY",
+            "sid": "ZTF",
             "mjd": 1.0,
             "fid": "g",
             "new": False,
@@ -225,7 +189,7 @@ def test_execute_removes_duplicates_keeping_ones_with_stamps(
         },
         {
             "aid": "aid1",
-            "oid": "ZTF456",
+            "oid": "ZTF123",
             "candid": "f",
             "parent_candid": "p_d",
             "has_stamp": True,
@@ -249,28 +213,42 @@ def test_execute_removes_duplicates_keeping_ones_with_stamps(
         },
         {
             "fid": "f",
-            "aid": "aid2",
+            "aid": "aid1",
             "sid": "ZTF",
             "tid": "ZTF",
             "mjd": 3.0,
-            "oid": "ZTF456",
+            "oid": "ZTF123",
             "diffmaglim": 1,
         },
     ]
 
     message = {
-        "aids": {"aid1", "aid2"},
-        "oids": {
-            "ZTF456": "aid1",
-            "ZTF123": "aid2",
-            "oidy": "aid1",
-        },
-        "candids": {"aid1": ["a", "c"], "aid2": ["c"]},
-        "last_mjds": {"aid1": 4, "aid2": 5},
+        "oids": ["ZTF123", "ZTF456"],
+        "candids": {"ZTF123": ["d", "f"], "ZTF456": ["a"]},
+        "last_mjds": {"ZTF123": 1, "ZTF456": 1},
         "detections": [
             {
                 "aid": "aid1",
-                "oid": "oid1",
+                "oid": "ZTF456",
+                "sid": "ZTF",
+                "parent_candid": "p_a",
+                "candid": "a",
+                "fid": "g",
+                "mjd": 3,
+                "has_stamp": True,
+                "extra_fields": {},
+                "new": True,
+            },
+        ],
+        "non_detections": [],
+    }
+
+    output = step.execute(message)
+    expected = {
+        "detections": [
+            {
+                "aid": "aid1",
+                "oid": "ZTF456",
                 "sid": "ZTF",
                 "parent_candid": "p_a",
                 "candid": "a",
@@ -281,108 +259,20 @@ def test_execute_removes_duplicates_keeping_ones_with_stamps(
                 "new": True,
             },
             {
-                "aid": "aid2",
-                "oid": "oid3",
-                "sid": "ZTF",
-                "candid": "c",
-                "parent_candid": "p_c",
-                "fid": "g",
-                "mjd": 4,
-                "has_stamp": True,
-                "extra_fields": {},
-                "new": True,
-            },
-            {
                 "aid": "aid1",
-                "oid": "oid1",
-                "sid": "ZTF",
-                "parent_candid": "p_b",
-                "fid": "g",
-                "candid": "b",
-                "mjd": 2,
-                "has_stamp": True,
-                "extra_fields": {},
-                "new": True,
-            },
-            {
-                "aid": "aid2",
-                "oid": "oid2",
-                "sid": "ATLAS",
-                "fid": "g",
-                "candid": "b",
-                "mjd": 4,
-                "has_stamp": True,
-                "extra_fields": {},
-                "new": True,
-            },
-        ],
-        "non_detections": [
-            {
-                "mjd": 1,
-                "oid": "oid1",
-                "fid": "c",
-                "aid": "aid1",
-                "diffmaglim": 0.8,
-                "sid": "ATLAS",
-                "tid": "ATLAS-01a",
-            },
-        ],
-    }
-
-    output = step.execute(message)
-    expected = {
-        "detections": [
-            {
-                "oid": "oidy",
-                "candid": "97923792234",
-                "mjd": 1.0,
-                "aid": "aid1",
-                "parent_candid": "p_a",
-                "has_stamp": True,
-                "sid": "SURVEY",
-                "fid": "g",
-                "new": False,
-                "extra_fields": {},
-            },
-            {
-                "candid": "c",
-                "mjd": 4.0,
-                "oid": "oid3",
-                "aid": "aid2",
-                "parent_candid": "p_c",
-                "has_stamp": True,
-                "sid": "ZTF",
-                "fid": "g",
-                "new": True,
-                "extra_fields": {},
-            },
-            {
-                "candid": "b",
-                "mjd": 2.0,
-                "oid": "oid1",
-                "aid": "aid1",
-                "parent_candid": "p_b",
-                "has_stamp": True,
-                "sid": "ZTF",
-                "fid": "g",
-                "new": True,
-                "extra_fields": {},
-            },
-            {
-                "candid": "d",
-                "mjd": 1.0,
                 "oid": "ZTF123",
-                "aid": "aid2",
+                "candid": "d",
                 "parent_candid": "p_d",
                 "has_stamp": True,
                 "sid": "ZTF",
+                "mjd": 1.0,
                 "fid": "g",
                 "new": False,
                 "extra_fields": {},
             },
             {
                 "aid": "aid1",
-                "oid": "ZTF456",
+                "oid": "ZTF123",
                 "candid": "f",
                 "parent_candid": "p_d",
                 "has_stamp": True,
@@ -392,49 +282,28 @@ def test_execute_removes_duplicates_keeping_ones_with_stamps(
                 "new": False,
                 "extra_fields": {},
             },
-            {
-                "aid": "aid1",
-                "oid": "oid1",
-                "fid": "g",
-                "sid": "ZTF",
-                "parent_candid": "p_a",
-                "candid": "a",
-                "mjd": 3,
-                "has_stamp": True,
-                "extra_fields": {},
-                "new": True,
-            },
         ],
         "non_detections": [
             {
-                "mjd": 1.0,
                 "aid": "aid1",
-                "oid": "oid1",
-                "diffmaglim": 0.8,
-                "fid": "c",
-                "sid": "ATLAS",
-                "tid": "ATLAS-01a",
+                "sid": "ZTF",
+                "tid": "ZTF",
+                "oid": "ZTF123",
+                "fid": "g",
+                "mjd": 2.0,
+                "diffmaglim": 1,
             },
             {
-                "mjd": 2.0,
+                "fid": "f",
                 "aid": "aid1",
+                "sid": "ZTF",
+                "tid": "ZTF",
+                "mjd": 3.0,
                 "oid": "ZTF123",
                 "diffmaglim": 1,
-                "fid": "g",
-                "sid": "ZTF",
-                "tid": "ZTF",
-            },
-            {
-                "mjd": 3.0,
-                "aid": "aid2",
-                "oid": "ZTF456",
-                "diffmaglim": 1,
-                "fid": "f",
-                "sid": "ZTF",
-                "tid": "ZTF",
             },
         ],
-        "last_mjds": {"aid1": 1.0, "aid2": 1.0},
+        "last_mjds": {"ZTF123": 1.0, "ZTF456": 1.0},
     }
 
     exp_dets = pd.DataFrame(expected["detections"])
@@ -445,8 +314,8 @@ def test_execute_removes_duplicates_keeping_ones_with_stamps(
         check_like=True,
     )
     assert_frame_equal(
-        output["non_detections"].set_index(["aid", "fid", "mjd"]),
-        exp_nd.set_index(["aid", "fid", "mjd"]),
+        output["non_detections"].set_index(["oid", "fid", "mjd"]),
+        exp_nd.set_index(["oid", "fid", "mjd"]),
         check_like=True,
     )
 
@@ -456,6 +325,7 @@ def test_pre_produce_restores_messages(env_variables):
         "detections": pd.DataFrame(
             [
                 {
+                    "oid": "oid1",
                     "candid": "a",
                     "mjd": 1,
                     "has_stamp": True,
@@ -464,6 +334,7 @@ def test_pre_produce_restores_messages(env_variables):
                     "extra_fields": {"diaObject": b"bainari"},
                 },
                 {
+                    "oid": "oid1",
                     "candid": "c",
                     "mjd": 1,
                     "new": True,
@@ -472,14 +343,16 @@ def test_pre_produce_restores_messages(env_variables):
                     "extra_fields": {},
                 },
                 {
+                    "oid": "oid1",
                     "candid": "MOST_RECENT",
                     "mjd": 2,
                     "has_stamp": True,
                     "aid": "AID1",
-                    "new": False,
+                    "new": True,
                     "extra_fields": {"diaObject": [{"a": "b"}]},
                 },
                 {
+                    "oid": "oid2",
                     "candid": "b",
                     "mjd": 1,
                     "new": False,
@@ -491,12 +364,12 @@ def test_pre_produce_restores_messages(env_variables):
         ),
         "non_detections": pd.DataFrame(
             [
-                {"mjd": 1, "oid": "a", "fid": 1, "aid": "AID1"},
-                {"mjd": 1, "oid": "b", "fid": 1, "aid": "AID2"},
+                {"mjd": 1, "oid": "oid1", "fid": 1, "aid": "AID1"},
+                {"mjd": 1, "oid": "oid2", "fid": 1, "aid": "AID2"},
             ]
         ),
-        "last_mjds": {"AID1": 1, "AID2": 1},
-        "candids": {"AID1": ["a", "MOST_RECENT"], "AID2": ["c", "b"]},
+        "last_mjds": {"oid1": 2, "oid2": 1},
+        "candids": {"oid1": ["a"], "oid2": ["b"]},
     }
 
     output = LightcurveStep(
@@ -506,25 +379,19 @@ def test_pre_produce_restores_messages(env_variables):
     # This one has the object with MOST_RECENT candid removed
     expected = [
         {
-            "aid": "AID1",
+            "oid": "oid1",
             "detections": [
                 {
+                    "oid": "oid1",
                     "candid": "a",
-                    "has_stamp": True,
                     "mjd": 1,
-                    "new": True,
+                    "has_stamp": True,
                     "aid": "AID1",
+                    "new": True,
                     "extra_fields": {"diaObject": b"bainari"},
                 },
-            ],
-            "non_detections": [{"mjd": 1, "oid": "a", "fid": 1, "aid": "AID1"}],
-            "candid": ["a", "MOST_RECENT"],
-        },
-        {
-            "aid": "AID2",
-            "candid": ["c", "b"],
-            "detections": [
                 {
+                    "oid": "oid1",
                     "candid": "c",
                     "mjd": 1,
                     "new": True,
@@ -533,6 +400,26 @@ def test_pre_produce_restores_messages(env_variables):
                     "extra_fields": {},
                 },
                 {
+                    "oid": "oid1",
+                    "candid": "MOST_RECENT",
+                    "mjd": 2,
+                    "has_stamp": True,
+                    "aid": "AID1",
+                    "new": True,
+                    "extra_fields": {"diaObject": pickle.dumps([{"a": "b"}])},
+                },
+            ],
+            "non_detections": [
+                {"mjd": 1, "oid": "oid1", "fid": 1, "aid": "AID1"}
+            ],
+            "candid": ["a"],
+        },
+        {
+            "oid": "oid2",
+            "candid": ["b"],
+            "detections": [
+                {
+                    "oid": "oid2",
                     "candid": "b",
                     "mjd": 1,
                     "new": False,
@@ -541,7 +428,9 @@ def test_pre_produce_restores_messages(env_variables):
                     "extra_fields": {},
                 },
             ],
-            "non_detections": [{"mjd": 1, "oid": "b", "fid": 1, "aid": "AID2"}],
+            "non_detections": [
+                {"mjd": 1, "oid": "oid2", "fid": 1, "aid": "AID2"}
+            ],
         },
     ]
 

--- a/schemas/lightcurve_step/output.avsc
+++ b/schemas/lightcurve_step/output.avsc
@@ -4,7 +4,7 @@
   "name": "Lightcurve",
   "fields": [
     {
-      "name": "aid",
+      "name": "oid",
       "type": "string"
     },
     {
@@ -48,10 +48,7 @@
             },
             {
               "name": "candid",
-              "type": [
-                "long",
-                "string"
-              ]
+              "type": ["long", "string"]
             },
             {
               "name": "mjd",
@@ -99,25 +96,14 @@
             },
             {
               "name": "parent_candid",
-              "type": [
-                "long",
-                "string",
-                "null"
-              ]
+              "type": ["long", "string", "null"]
             },
             {
               "name": "extra_fields",
               "type": {
                 "default": {},
                 "type": "map",
-                "values": [
-                  "null",
-                  "int",
-                  "float",
-                  "string",
-                  "bytes",
-                  "boolean"
-                ]
+                "values": ["null", "int", "float", "string", "bytes", "boolean"]
               }
             }
           ]

--- a/schemas/prv_candidate_step/output.avsc
+++ b/schemas/prv_candidate_step/output.avsc
@@ -4,7 +4,7 @@
   "name": "prv_candidates",
   "fields": [
     {
-      "name": "aid",
+      "name": "oid",
       "type": "string"
     },
     {
@@ -89,24 +89,14 @@
             },
             {
               "name": "parent_candid",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             {
               "name": "extra_fields",
               "type": {
                 "default": {},
                 "type": "map",
-                "values": [
-                  "null",
-                  "int",
-                  "float",
-                  "string",
-                  "bytes",
-                  "boolean"
-                ]
+                "values": ["null", "int", "float", "string", "bytes", "boolean"]
               }
             }
           ]

--- a/scribe/mongo_scribe/mongo/command/commands.py
+++ b/scribe/mongo_scribe/mongo/command/commands.py
@@ -86,10 +86,12 @@ class UpdateCommand(Command):
         if not criteria:
             raise UpdateWithNoCriteriaException()
         if collection == "forced_photometry":
-            self.criteria = { "_id": criteria["_id"] }
+            self.criteria = {"_id": criteria["_id"]}
 
     def get_operations(self) -> list:
         op = "$setOnInsert" if self.options.set_on_insert else "$set"
+        print("criteria", self.criteria)
+        print("data", self.data)
         return [
             UpdateOne(
                 self.criteria, {op: self.data}, upsert=self.options.upsert

--- a/scribe/mongo_scribe/mongo/command/decode.py
+++ b/scribe/mongo_scribe/mongo/command/decode.py
@@ -20,10 +20,6 @@ def validate(message: dict) -> dict:
     if "options" not in message:
         message["options"] = {}
 
-    # WARNING: this one is hard to assume
-    if "oid" in message["criteria"]:
-        message["criteria"].pop("oid")
-
     return message
 
 

--- a/scribe/poetry.lock
+++ b/scribe/poetry.lock
@@ -337,7 +337,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "db-plugins"
-version = "6.1.1a47"
+version = "6.1.1a63"
 description = "ALeRCE database plugins."
 optional = false
 python-versions = ">=3.7, <3.12"

--- a/scribe/tests/conftest.py
+++ b/scribe/tests/conftest.py
@@ -16,7 +16,7 @@ def docker_compose_file(pytestconfig):
 
 
 def is_mongo_responsive(ip, port):
-    client = MongoClient(f"mongodb://mongo:mongo@{ip}:{port}")
+    client = MongoClient(f"mongodb://{ip}:{port}")
     try:
         client.admin.command("ismaster")
         return True

--- a/scribe/tests/integration/docker-compose.yml
+++ b/scribe/tests/integration/docker-compose.yml
@@ -22,13 +22,10 @@ services:
 
   mongodb:
     image: mongo
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: mongo
-      MONGO_INITDB_ROOT_PASSWORD: mongo
     ports:
       - "27017:27017"
     command: mongod --notablescan
-  
+
   postgres:
     image: postgres
     environment:

--- a/scribe/tests/integration/test_batch.py
+++ b/scribe/tests/integration/test_batch.py
@@ -10,8 +10,8 @@ from _generator import CommandGenerator
 DB_CONFIG = {
     "MONGO": {
         "host": "localhost",
-        "username": "mongo",
-        "password": "mongo",
+        "username": "",
+        "password": "",
         "port": 27017,
         "database": "test",
     }

--- a/scribe/tests/integration/test_step.py
+++ b/scribe/tests/integration/test_step.py
@@ -314,7 +314,6 @@ class MongoIntegrationTest(unittest.TestCase):
                 "type": "update",
                 "criteria": {
                     "oid": "ZTF12345",
-                    "aid": "ALX534311",
                     "fid": "g",
                     "mjd": 55500,
                 },
@@ -329,7 +328,6 @@ class MongoIntegrationTest(unittest.TestCase):
                 "type": "update",
                 "criteria": {
                     "oid": "ZTF12345",
-                    "aid": "ALX534311",
                     "fid": "g",
                     "mjd": 55500,
                 },
@@ -346,7 +344,6 @@ class MongoIntegrationTest(unittest.TestCase):
                 "type": "update",
                 "criteria": {
                     "oid": "ZTF12345",
-                    "aid": "ALX534311",
                     "fid": "g",
                     "mjd": 55500,
                 },
@@ -358,8 +355,8 @@ class MongoIntegrationTest(unittest.TestCase):
         self.producer.producer.flush(1)
         self.step.start()
         collection = self.step.db_client.connection.database["non_detection"]
-        result = collection.find_one({"aid": "ALX534311"})
-        print(result)
+        result = collection.find_one({"oid": "ZTF12345"})
+        assert result
 
     def test_print_into_console(self):
         os.environ["MOCK_DB_COLLECTION"] = "True"

--- a/scribe/tests/integration/test_step.py
+++ b/scribe/tests/integration/test_step.py
@@ -9,8 +9,8 @@ from db_plugins.db.mongo._connection import MongoConnection
 DB_CONFIG = {
     "MONGO": {
         "host": "localhost",
-        "username": "mongo",
-        "password": "mongo",
+        "username": "",
+        "password": "",
         "port": 27017,
         "database": "test",
     }
@@ -59,10 +59,12 @@ class MongoIntegrationTest(unittest.TestCase):
         cls.producer = KafkaProducer(config=PRODUCER_CONFIG)
 
     def tearDown(self):
-        object_collection = self.db.database["object"]
-        object_collection.delete_many({})
-        object_detection = self.db.database["detection"]
-        object_detection.delete_many({})
+        collection = self.db.database["object"]
+        collection.delete_many({})
+        collection = self.db.database["detection"]
+        collection.delete_many({})
+        collection = self.db.database["non_detection"]
+        collection.delete_many({})
 
     def test_insert_into_database(self):
         command = json.dumps(


### PR DESCRIPTION
## Summary of the changes

- Uses oid to group lightcurve, this includes detections, non detections and forced_photometry
- Fixes prv detections handling when merging data from the stream and the database

## Observations

This PR updates the indices of the Detection, NonDetection, ForcedPhotometry and Object collections.

### Misc
Added a feature to the `apf.consumers.KafkaConsumer` to make cleanup operations after consuming. This is helpful when a consumer does not close after the Kafka container exits.

Also added extra cleanup procedures for tests and in the step itself.

## If the change is BREAKING, please give more details about the breaking changes

There are 2 breaking changes:

1. Oid to group lightcurve
2. Output schema replaced aid for oid in the root of the message
3. Mongo database indices for Object, Detection, Non Detection and ForcedPhotometry collections

#### Components that need updates and steps to follow

1. The database needs to be recreated to add the new index.
2. The correction step needs to update to the new schema
3. The correction step needs to update to use oid grouping

## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.