### PR TITLE
Refactor LC Classification Step: Use oid to group objects

### DIFF
--- a/.github/workflows/template_build_with_dagger.yaml
+++ b/.github/workflows/template_build_with_dagger.yaml
@@ -30,7 +30,6 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
-          ref: main
           submodules: ${{ inputs.submodules}}
           token: ${{ secrets.GH_TOKEN }}
       - name: Install poetry

--- a/.github/workflows/xmatch_step.yaml
+++ b/.github/workflows/xmatch_step.yaml
@@ -5,39 +5,38 @@ on:
     branches:
       - main
     paths:
-      - 'xmatch_step/**'
-      - '!xmatch_step/README.md'
+      - "xmatch_step/**"
+      - "!xmatch_step/README.md"
 
 jobs:
   xmatch_step_lint:
     uses: ./.github/workflows/lint-template.yaml
     with:
-      base-folder: 'xmatch_step'
-      sources-folder: 'xmatch_step'
+      base-folder: "xmatch_step"
+      sources-folder: "xmatch_step"
   xmatch_step_unittest:
     uses: ./.github/workflows/poetry-tests-template.yaml
     with:
-      base-folder: 'xmatch_step'
-      python-version: "3.7"
+      base-folder: "xmatch_step"
+      python-version: "3.10"
       test-folder: "tests/unittest"
     secrets:
-      GH_TOKEN: '${{ secrets.ADMIN_TOKEN }}'
+      GH_TOKEN: "${{ secrets.ADMIN_TOKEN }}"
   xmatch_step_integration:
     uses: ./.github/workflows/poetry-tests-template.yaml
     with:
-      base-folder: 'xmatch_step'
-      python-version: '3.7'
-      sources-folder: 'xmatch_step'
-      test-folder: 'tests/integration'
-      codecov-flags: ''  # Do not upload
+      base-folder: "xmatch_step"
+      python-version: "3.10"
+      sources-folder: "xmatch_step"
+      test-folder: "tests/integration"
+      codecov-flags: "" # Do not upload
     secrets:
-      GH_TOKEN: '${{ secrets.ADMIN_TOKEN }}'
+      GH_TOKEN: "${{ secrets.ADMIN_TOKEN }}"
 
   build-xmatch-dagger:
-    
     uses: ./.github/workflows/template_build_with_dagger.yaml
     with:
-        stage: staging
-        extra-args: xmatch_step --dry-run
+      stage: staging
+      extra-args: xmatch_step --dry-run
     secrets:
-        GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+      GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}

--- a/lc_classification_step/.gitignore
+++ b/lc_classification_step/.gitignore
@@ -8,3 +8,4 @@ htmlcov/
 __SUCCESS__
 .env
 .env.test
+.env.el

--- a/lc_classification_step/lc_classification/core/parsers/elasticc_parser.py
+++ b/lc_classification_step/lc_classification/core/parsers/elasticc_parser.py
@@ -32,7 +32,7 @@ class ElasticcParser(KafkaParser):
             ]
 
             if len(new_detection) == 0:
-                ## case when no new detections
+                # case when no new detections
                 new_detection = [
                     det for det in message["detections"] if det["has_stamp"]
                 ]
@@ -47,9 +47,7 @@ class ElasticcParser(KafkaParser):
 
             new_detection = new_detection[0]
 
-            # terrible parche (este codigo es transicional,
-            # cambiar antes de la semana del congreso)
-            detection_extra_info[new_detection["aid"]] = {
+            detection_extra_info[new_detection["oid"]] = {
                 "candid": new_detection["extra_fields"].get(
                     "alertId", new_detection["candid"]
                 ),
@@ -68,14 +66,14 @@ class ElasticcParser(KafkaParser):
         predictions = NoClassifiedPostProcessor(
             messages, predictions
         ).get_modified_classifications()
-        predictions["aid"] = predictions.index
+        predictions["oid"] = predictions.index
         for class_name in self.ClassMapper.get_class_names():
             if class_name not in predictions.columns:
                 predictions[class_name] = 0.0
         classifications = predictions.to_dict(orient="records")
         output = []
         for classification in classifications:
-            aid = classification.pop("aid")
+            oid = classification.pop("oid")
             if "classifier_name" in classification:
                 classification.pop("classifier_name")
 
@@ -86,14 +84,15 @@ class ElasticcParser(KafkaParser):
                 }
                 for predicted_class, prob in classification.items()
             ]
+            print(detection_extra_info)
             response = {
-                "alertId": int(detection_extra_info[aid]["candid"]),
-                "diaSourceId": int(detection_extra_info[aid]["diaSourceId"]),
+                "alertId": int(detection_extra_info[oid]["candid"]),
+                "diaSourceId": int(detection_extra_info[oid]["diaSourceId"]),
                 "elasticcPublishTimestamp": int(
-                    detection_extra_info[aid]["elasticcPublishTimestamp"]
+                    detection_extra_info[oid]["elasticcPublishTimestamp"]
                 ),
                 "brokerIngestTimestamp": int(
-                    detection_extra_info[aid]["brokerIngestTimestamp"]
+                    detection_extra_info[oid]["brokerIngestTimestamp"]
                 ),
                 "classifications": output_classification,
                 "brokerVersion": classifier_version,

--- a/lc_classification_step/lc_classification/core/parsers/input_dto.py
+++ b/lc_classification_step/lc_classification/core/parsers/input_dto.py
@@ -32,40 +32,40 @@ def create_detections_dto(messages: List[dict]) -> pd.DataFrame:
     >>> messages = [
             {
                 "detections": [
-                    {"aid": "aid1", "candid": "cand1"},
-                    {"aid": "aid1", "candid": "cand2"},
+                    {"oid": "oid1", "candid": "cand1"},
+                    {"oid": "oid1", "candid": "cand2"},
                 ]
             },
             {
                 "detections": [
-                    {"aid": "aid2", "candid": "cand3"},
+                    {"oid": "oid2", "candid": "cand3"},
                 ]
             },
         ]
     >>> create_detections_dto(messages)
                 candid
-        aid
-        aid1    cand1
-        aid2    cand3
+        oid
+        oid1    cand1
+        oid2    cand3
     """
     detections = [
         pd.DataFrame.from_records(msg["detections"]) for msg in messages
     ]
     detections = pd.concat(detections)
     detections.drop_duplicates("candid", inplace=True)
-    detections = detections.set_index("aid")
+    detections = detections.set_index("oid")
     detections["extra_fields"] = parse_extra_fields(detections)
 
     if detections is not None:
         return detections
     else:
-        raise ValueError("Could not set index aid on features dataframe")
+        raise ValueError("Could not set index oid on features dataframe")
 
 
 def parse_extra_fields(detections: pd.DataFrame) -> List[dict]:
     for ef in detections["extra_fields"]:
         for key in ef.copy():
-            if type(ef[key]) == bytes:
+            if type(ef[key]) is bytes:
                 extra_field = pickle.loads(ef[key])
                 # the loaded pickle is a list of one element
                 ef[key] = extra_field[0]
@@ -75,40 +75,40 @@ def parse_extra_fields(detections: pd.DataFrame) -> List[dict]:
 def create_features_dto(messages: List[dict]) -> pd.DataFrame:
     """Creates a pandas dataframe with all the features from all messages
 
-    The index is the aid and each feature is a column.
+    The index is the oid and each feature is a column.
 
     Parameters
     -------
     messages : list
-        a list of dictionaries with at least aid and features keys.
+        a list of dictionaries with at least oid and features keys.
     Returns
     -------
     pd.DataFrame
-        A dataframe where each feature is a column indexed by aid.
-        Duplicated aid are removed.
+        A dataframe where each feature is a column indexed by oid.
+        Duplicated oid are removed.
 
     Examples
     --------
     >>> messages = [
             {
-                'aid': 'aid1',
+                'oid': 'oid1',
                 'features': {'feat1': 1, 'feat2': 2}
             },
             {
-                'aid': 'aid1',
+                'oid': 'oid1',
                 'features': {'feat1': 2, 'feat2': 3}
             },
             {
-                'aid': 'aid2',
+                'oid': 'oid2',
                 'features': {'feat1': 4, 'feat2': 5}
             }
         ]
     >>> create_features_dto(messages)
 
         feat1  feat2
-    aid
-    aid2      4      5
-    aid1      2      3
+    oid
+    oid2      4      5
+    oid1      2      3
     """
     if len(messages) == 0 or "features" not in messages[0]:
         return pd.DataFrame()
@@ -119,15 +119,15 @@ def create_features_dto(messages: List[dict]) -> pd.DataFrame:
         entry = {
             feat: message["features"][feat] for feat in message["features"]
         }
-        entry["aid"] = message["aid"]
+        entry["oid"] = message["oid"]
         entries.append(entry)
     if len(entries) == 0:
         return pd.DataFrame()
 
     features = pd.DataFrame.from_records(entries)
-    features.drop_duplicates("aid", inplace=True, keep="last")
-    features = features.set_index("aid")
+    features.drop_duplicates("oid", inplace=True, keep="last")
+    features = features.set_index("oid")
     if features is not None:
         return features
     else:
-        raise ValueError("Could not set index aid on features dataframe")
+        raise ValueError("Could not set index oid on features dataframe")

--- a/lc_classification_step/lc_classification/core/parsers/scribe_parser.py
+++ b/lc_classification_step/lc_classification/core/parsers/scribe_parser.py
@@ -33,24 +33,24 @@ class ScribeParser(KafkaParser):
 
             {
                 'top':                     Periodic  Stochastic  Transient
-                            aid
+                            oid
                             vbKsodtqMI     0.434        0.21      0.356,
                 'children': {
                     'Transient':                    SLSN   SNII   SNIa  SNIbc
-                                        aid
+                                        oid
                                         vbKsodtqMI  0.082  0.168  0.444  0.306,
                     'Stochastic':                   AGN  Blazar  CV/Nova   QSO    YSO
-                                        aid
+                                        oid
                                         vbKsodtqMI  0.032   0.056    0.746  0.01  0.156,
                     'Periodic':                     CEP    DSCT   E      LPV    Periodic-Other    RRL
-                                        aid
+                                        oid
                                         vbKsodtqMI  0.218  0.082  0.158  0.028  0.12            0.394
                 }
             }
 
         to_parse.probabilities
                             SLSN      SNII      SNIa     SNIbc  ...         E       LPV  Periodic-Other       RRL
-              aid                                                 ...
+              oid                                                 ...
               vbKsodtqMI  0.029192  0.059808  0.158064  0.108936  ...  0.068572  0.012152         0.05208  0.170996,
         }
         """
@@ -64,9 +64,9 @@ class ScribeParser(KafkaParser):
         results = [top, probabilities]
 
         results = pd.concat(results)
-        if not results.index.name == "aid":
+        if not results.index.name == "oid":
             try:
-                results.set_index("aid", inplace=True)
+                results.set_index("oid", inplace=True)
             except KeyError as e:
                 if not is_all_strings(results.index.values):
                     raise e
@@ -81,7 +81,6 @@ class ScribeParser(KafkaParser):
                     "type": "update_probabilities",
                     "criteria": {
                         "_id": idx,
-                        "oid": kwargs["oids"].get(idx, []),
                     },
                     "data": {
                         "classifier_name": row["classifier_name"],
@@ -94,8 +93,8 @@ class ScribeParser(KafkaParser):
                 commands.append(command)
             return classifications_by_classifier
 
-        for aid in results.index.unique():
-            results.loc[[aid], :].groupby(
+        for oid in results.index.unique():
+            results.loc[[oid], :].groupby(
                 "classifier_name", group_keys=False
             ).apply(get_scribe_messages)
 

--- a/lc_classification_step/lc_classification/core/utils/no_class_post_processor.py
+++ b/lc_classification_step/lc_classification/core/utils/no_class_post_processor.py
@@ -11,28 +11,28 @@ class NoClassifiedPostProcessor(object):
         self.classifications = classifications
 
     def get_modified_classifications(self) -> pd.DataFrame:
-        if self.messages.index.name != "aid":
-            self.messages.set_index("aid", inplace=True)
+        if self.messages.index.name != "oid":
+            self.messages.set_index("oid", inplace=True)
         classifications_columns = self.classifications.columns.values.tolist()
         result_columns_names = classifications_columns + [self.class_name]
         classifications_cloumns_length = len(classifications_columns)
         no_classified_data = ([0] * classifications_cloumns_length) + [1]
 
         result_data = []
-        result_aids = []
+        result_oids = []
 
-        for aid, _ in self.messages.iterrows():
+        for oid, _ in self.messages.iterrows():
             try:
-                aid_classifications = list(self.classifications.loc[aid]) + [0]
+                oid_classifications = list(self.classifications.loc[oid]) + [0]
             except KeyError:
-                aid_classifications = no_classified_data
+                oid_classifications = no_classified_data
 
-            result_aids.append(aid)
-            result_data.append(aid_classifications)
+            result_oids.append(oid)
+            result_data.append(oid_classifications)
 
         result_df = pd.DataFrame(
-            result_data, index=result_aids, columns=result_columns_names
+            result_data, index=result_oids, columns=result_columns_names
         )
-        result_df.index.name = "aid"
+        result_df.index.name = "oid"
 
         return result_df

--- a/lc_classification_step/poetry.lock
+++ b/lc_classification_step/poetry.lock
@@ -1150,7 +1150,7 @@ files = [
 ]
 
 [[package]]
-name = "lc-classifier"
+name = "lc_classifier"
 version = "2.1.0"
 description = "ALeRCE light curve classifier"
 optional = false
@@ -1182,7 +1182,7 @@ wget = ">=3.2"
 type = "git"
 url = "https://github.com/alercebroker/lc_classifier"
 reference = "main"
-resolved_reference = "97b4b6ca0a1ddd02c881c24c0cd38b322ec159a6"
+resolved_reference = "3fdeba3bf82e8f5d1e64fd6f1b37b3bb622d1c04"
 
 [[package]]
 name = "libclang"

--- a/lc_classification_step/settings.py
+++ b/lc_classification_step/settings.py
@@ -155,5 +155,8 @@ def config():
         "FEATURE_FLAGS": {
             "PROMETHEUS": bool(os.getenv("USE_PROMETHEUS", True)),
             "USE_PROFILING": bool(os.getenv("USE_PROFILING", False)),
+            "LOG_CLASS_DISTRIBUTION": bool(
+                os.getenv("LOG_CLASS_DISTRIBUTION", False)
+            ),
         },
     }

--- a/lc_classification_step/tests/integration/conftest.py
+++ b/lc_classification_step/tests/integration/conftest.py
@@ -243,15 +243,13 @@ def _produce_messages(
     )
     random.seed(42)
     messages = generate_many(SCHEMA, 2)
-    producer.set_key_field("aid")
+    producer.set_key_field("oid")
 
     for message in messages:
         for det in message["detections"]:
-            det["aid"] = message["aid"]
+            det["oid"] = message["oid"]
             det["candid"] = random.randint(0, 100000)
             det["extra_fields"] = generate_extra_fields()
-            if topic == "features_elasticc":
-                det["oid"] = random.randint(0, 100000)
         message["detections"][0]["new"] = True
         message["detections"][0]["has_stamp"] = True
         if topic == "features_ztf":

--- a/lc_classification_step/tests/mockdata/mock_data_for_utils.py
+++ b/lc_classification_step/tests/mockdata/mock_data_for_utils.py
@@ -2,22 +2,22 @@ import pandas as pd
 
 messages_df = pd.DataFrame(
     [
-        "oid1",
-        "oid2",
-        "oid3",
-        "oid4",
-        "oid5",
-    ],
-    index=[
         "aid1",
         "aid2",
         "aid3",
         "aid4",
         "aid5",
     ],
-    columns=["oid"],
+    index=[
+        "oid1",
+        "oid2",
+        "oid3",
+        "oid4",
+        "oid5",
+    ],
+    columns=["aid"],
 )
-messages_df.index.name = "aid"
+messages_df.index.name = "oid"
 
 complete_classifications_df = pd.DataFrame(
     [
@@ -28,11 +28,11 @@ complete_classifications_df = pd.DataFrame(
         [0.6, 0.2, 0.2],
     ],
     index=[
-        "aid1",
-        "aid2",
-        "aid3",
-        "aid4",
-        "aid5",
+        "oid1",
+        "oid2",
+        "oid3",
+        "oid4",
+        "oid5",
     ],
     columns=[
         "class1",
@@ -40,7 +40,7 @@ complete_classifications_df = pd.DataFrame(
         "class3",
     ],
 )
-complete_classifications_df.index.name = "aid"
+complete_classifications_df.index.name = "oid"
 
 incomplete_classifications_df = pd.DataFrame(
     [
@@ -49,9 +49,9 @@ incomplete_classifications_df = pd.DataFrame(
         [0.6, 0.2, 0.2],
     ],
     index=[
-        "aid1",
-        "aid3",
-        "aid5",
+        "oid1",
+        "oid3",
+        "oid5",
     ],
     columns=[
         "class1",
@@ -59,4 +59,4 @@ incomplete_classifications_df = pd.DataFrame(
         "class3",
     ],
 )
-incomplete_classifications_df.index.name = "aid"
+incomplete_classifications_df.index.name = "oid"

--- a/lc_classification_step/tests/test_commons.py
+++ b/lc_classification_step/tests/test_commons.py
@@ -2,7 +2,7 @@ from pytest import approx
 
 
 def assert_ztf_object_is_correct(obj):
-    assert "aid" in obj
+    assert "oid" in obj
     assert "features" in obj
     assert "lc_classification" in obj
     assert "class" in obj["lc_classification"]
@@ -35,5 +35,4 @@ def assert_command_is_correct(command):
     assert command["collection"] == "object"
     assert command["type"] == "update_probabilities"
     assert command["criteria"]["_id"] is not None
-    assert "aid" not in command["data"]
     assert not command["options"]["set_on_insert"]

--- a/lc_classification_step/tests/unit/conftest.py
+++ b/lc_classification_step/tests/unit/conftest.py
@@ -132,8 +132,8 @@ def step_factory(messages, config, model):
 @pytest.fixture
 def ztf_model_output():
     def output_factory(messages_ztf, model):
-        aids = [
-            message["aid"]
+        oids = [
+            message["oid"]
             for message in messages_ztf
             if message.get("features") is not None
         ]
@@ -141,28 +141,28 @@ def ztf_model_output():
             "hierarchical": {
                 "top": DataFrame(
                     {
-                        "aid": aids,
-                        "CLASS": [1] * len(aids),
-                        "CLASS2": [0] * len(aids),
+                        "oid": oids,
+                        "CLASS": [1] * len(oids),
+                        "CLASS2": [0] * len(oids),
                     }
                 ),
                 "children": {
                     "Transient": DataFrame(
-                        {"aid": aids, "CLASS": [1] * len(aids)}
+                        {"oid": oids, "CLASS": [1] * len(oids)}
                     ),
                     "Stochastic": DataFrame(
-                        {"aid": aids, "CLASS": [1] * len(aids)}
+                        {"oid": oids, "CLASS": [1] * len(oids)}
                     ),
                     "Periodic": DataFrame(
-                        {"aid": aids, "CLASS": [1] * len(aids)}
+                        {"oid": oids, "CLASS": [1] * len(oids)}
                     ),
                 },
             },
             "probabilities": DataFrame(
                 {
-                    "aid": aids,
-                    "CLASS": [1] * len(aids),
-                    "CLASS2": [0] * len(aids),
+                    "oid": oids,
+                    "CLASS": [1] * len(oids),
+                    "CLASS2": [0] * len(oids),
                 }
             ),
         }
@@ -173,8 +173,8 @@ def ztf_model_output():
 @pytest.fixture
 def elasticc_model_output():
     def factory(_, model):
-        aids = ["aid1", "aid2"]
-        df = DataFrame({"C1": [0.5, 0.9], "C2": [0.5, 0.1]}, index=aids)
+        oids = ["oid1", "oid2"]
+        df = DataFrame({"C1": [0.5, 0.9], "C2": [0.5, 0.1]}, index=oids)
         model.predict.return_value = OutputDTO(
             df, {"top": DataFrame(), "children": {}}
         )

--- a/lc_classification_step/tests/unit/test_alerce_parser.py
+++ b/lc_classification_step/tests/unit/test_alerce_parser.py
@@ -8,15 +8,15 @@ probabilities = DataFrame(
         "Ia": [0.5, 0.5, 0.5],
         "AGN": [0.4, 0.4, 0.4],
         "Meta/Other": [0.1, 0.1, 0.1],
-        "aid": ["aid1", "aid2", "aid3"],
+        "oid": ["oid1", "oid2", "oid3"],
         "classifier_name": ["test", "test", "test"],
     }
 )
-probabilities.set_index("aid", inplace=True)
+probabilities.set_index("oid", inplace=True)
 hierarchical = {
     "top": DataFrame(
         {
-            "aid": ["aid1", "aid2", "aid3"],
+            "oid": ["oid1", "oid2", "oid3"],
             "Periodic": [0.434, 0.434, 0.434],
             "Stochastic": [0.21, 0.21, 0.21],
             "Transient": [0.356, 0.356, 0.356],
@@ -25,19 +25,19 @@ hierarchical = {
     "children": {
         "Transient": DataFrame(
             {
-                "aid": ["aid1", "aid2", "aid3"],
+                "oid": ["oid1", "oid2", "oid3"],
                 "Ia": [0.5, 0.5, 0.5],
             }
         ),
         "Stochastic": DataFrame(
             {
-                "aid": ["aid1", "aid2", "aid3"],
+                "oid": ["oid1", "oid2", "oid3"],
                 "AGN": [0.4, 0.4, 0.4],
             }
         ),
         "Periodic": DataFrame(
             {
-                "aid": ["aid1", "aid2", "aid3"],
+                "oid": ["oid1", "oid2", "oid3"],
                 "Meta/Other": [0.1, 0.1, 0.1],
             }
         ),
@@ -49,8 +49,8 @@ messages = [
     {
         "detections": [
             {
-                "aid": "aid1",
                 "oid": 1,
+                "aid": "aid1",
                 "candid": 1,
                 "new": True,
                 "has_stamp": True,
@@ -61,14 +61,14 @@ messages = [
             }
         ],
         "non_detections": [],
-        "aid": "aid1",
+        "oid": "oid1",
         "features": {"feature1": 1},
     },
     {
         "detections": [
             {
                 "aid": "aid2",
-                "oid": 2,
+                "oid": 1,
                 "candid": 2,
                 "new": True,
                 "has_stamp": True,
@@ -79,7 +79,7 @@ messages = [
             }
         ],
         "non_detections": [],
-        "aid": "aid2",
+        "oid": "oid2",
         "features": {"feature1": 1},
     },
     {
@@ -97,7 +97,7 @@ messages = [
             }
         ],
         "non_detections": [],
-        "aid": "aid3",
+        "oid": "oid3",
         "features": {"feature1": 1},
     },
 ]

--- a/lc_classification_step/tests/unit/test_elasticc_parser.py
+++ b/lc_classification_step/tests/unit/test_elasticc_parser.py
@@ -7,10 +7,10 @@ probabilities = DataFrame(
         "Ia": ["0.5", "0.5", "0.5"],
         "AGN": ["0.4", "0.4", "0.4"],
         "Meta/Other": ["0.1", "0.1", "0.1"],
-        "aid": ["aid1", "aid2", "aid3"],
+        "oid": ["oid1", "oid2", "oid3"],
     }
 )
-probabilities.set_index("aid", inplace=True)
+probabilities.set_index("oid", inplace=True)
 hierarchical = {"top": DataFrame(), "children": {}}
 output_dto = OutputDTO(probabilities, hierarchical)
 
@@ -18,8 +18,8 @@ messages = [
     {
         "detections": [
             {
-                "aid": "aid1",
-                "oid": 11,
+                "oid": "oid1",
+                "aid": "11",
                 "candid": 1,
                 "mjd": 11,
                 "new": True,
@@ -30,8 +30,8 @@ messages = [
                 },
             },
             {
-                "aid": "aid1",
-                "oid": 1,
+                "oid": "oid1",
+                "aid": "1",
                 "candid": 22,
                 "mjd": 22,
                 "new": False,
@@ -43,13 +43,13 @@ messages = [
             },
         ],
         "non_detections": [],
-        "aid": "aid1",
+        "oid": "oid1",
     },
     {
         "detections": [
             {
-                "aid": "aid2",
-                "oid": 2,
+                "oid": "oid2",
+                "aid": "2",
                 "candid": 2,
                 "mjd": 2,
                 "new": True,
@@ -61,13 +61,13 @@ messages = [
             }
         ],
         "non_detections": [],
-        "aid": "aid2",
+        "oid": "oid2",
     },
     {
         "detections": [
             {
-                "aid": "aid3",
-                "oid": 3,
+                "oid": "oid3",
+                "aid": "3",
                 "candid": 3,
                 "mjd": 3,
                 "new": True,
@@ -79,13 +79,13 @@ messages = [
             }
         ],
         "non_detections": [],
-        "aid": "aid3",
+        "oid": "oid3",
     },
     {
         "detections": [
             {
-                "aid": "aid4",
-                "oid": 4,
+                "oid": "oid4",
+                "aid": "4",
                 "candid": 4,
                 "mjd": 4,
                 "new": True,
@@ -97,7 +97,7 @@ messages = [
             }
         ],
         "non_detections": [],
-        "aid": "aid4",
+        "oid": "oid4",
     },
 ]
 

--- a/lc_classification_step/tests/unit/test_input_dto.py
+++ b/lc_classification_step/tests/unit/test_input_dto.py
@@ -14,12 +14,12 @@ def test_create_detections_dto():
         {
             "detections": [
                 {
-                    "aid": "aid1",
+                    "oid": "oid1",
                     "candid": "cand1",
                     "extra_fields": extra_fields(),
                 },
                 {
-                    "aid": "aid1",
+                    "oid": "oid1",
                     "candid": "cand2",
                     "extra_fields": extra_fields(),
                 },
@@ -27,13 +27,13 @@ def test_create_detections_dto():
         },
         {
             "detections": [
-                {"aid": "aid2", "candid": "cand3", "extra_fields": {}},
+                {"oid": "oid2", "candid": "cand3", "extra_fields": {}},
             ]
         },
     ]
     detections = create_detections_dto(messages)
 
-    assert set(detections.index.tolist()) == set(["aid1", "aid2"])
+    assert set(detections.index.tolist()) == set(["oid1", "oid2"])
     assert len(detections.index) == 3
     assert list(detections["extra_fields"].values) == [
         {"ef1": {"data1": "data1"}, "ef2": "val2"},
@@ -44,28 +44,28 @@ def test_create_detections_dto():
 
 def test_create_features_dto():
     messages = [
-        {"aid": "aid1", "features": {"feat1": 1, "feat2": 2}},
-        {"aid": "aid1", "features": {"feat1": 2, "feat2": 3}},
-        {"aid": "aid2", "features": {"feat1": 4, "feat2": 5}},
-        {"aid": "aid3", "features": {"feat1": None, "feat2": None}},
-        {"aid": "aid4", "features": {"feat1": 4, "feat2": None}},
+        {"oid": "oid1", "features": {"feat1": 1, "feat2": 2}},
+        {"oid": "oid1", "features": {"feat1": 2, "feat2": 3}},
+        {"oid": "oid2", "features": {"feat1": 4, "feat2": 5}},
+        {"oid": "oid3", "features": {"feat1": None, "feat2": None}},
+        {"oid": "oid4", "features": {"feat1": 4, "feat2": None}},
     ]
     features = create_features_dto(messages)
-    assert features.loc["aid1", "feat1"] == 2
-    assert np.isnan(features.loc["aid4", "feat2"])
-    assert features.index.tolist() == ["aid1", "aid2", "aid3", "aid4"]
+    assert features.loc["oid1", "feat1"] == 2
+    assert np.isnan(features.loc["oid4", "feat2"])
+    assert features.index.tolist() == ["oid1", "oid2", "oid3", "oid4"]
 
 
 def test_create_features_dto_nofeats():
     messages = [
         {
-            "aid": "aid1",
+            "oid": "oid1",
         },
         {
-            "aid": "aid1",
+            "oid": "oid1",
         },
         {
-            "aid": "aid2",
+            "oid": "oid2",
         },
     ]
     features = create_features_dto(messages)

--- a/lc_classification_step/tests/unit/test_utils.py
+++ b/lc_classification_step/tests/unit/test_utils.py
@@ -1,7 +1,7 @@
 import pathlib
 import random
-from typing import List
 import unittest
+from typing import List
 
 import pandas as pd
 from fastavro import schema, utils
@@ -26,11 +26,11 @@ def generate_messages_elasticc() -> List[dict]:
     input_schema = schema.load_schema(schema_path)
     messages_elasticc = list(utils.generate_many(input_schema, 2))
 
-    for message in messages_elasticc:
+    for idx, message in enumerate(messages_elasticc):
+        message["oid"] = f"oid{idx+1}"
         for det in message["detections"]:
-            det["aid"] = message["aid"]
+            det["oid"] = message["oid"]
             det["candid"] = random.randint(0, 100000)
-            det["oid"] = random.randint(0, 100000)
             det["extra_fields"] = generate_extra_fields()
         message["detections"][0]["new"] = True
         message["detections"][0]["has_stamp"] = True
@@ -50,7 +50,7 @@ def generate_messages_ztf() -> List[dict]:
 
     for message in messages_ztf:
         for det in message["detections"]:
-            det["aid"] = message["aid"]
+            det["oid"] = message["oid"]
             det["extra_fields"] = {}
         message["detections"][0]["new"] = True
         message["detections"][0]["has_stamp"] = True
@@ -58,7 +58,7 @@ def generate_messages_ztf() -> List[dict]:
 
 
 class NoClassifiedPostProcessorTestCase(unittest.TestCase):
-    def test_all_aid_classified(self):
+    def test_all_oid_classified(self):
         expected_df = pd.DataFrame(
             [
                 [0.1, 0.2, 0.7, 0],
@@ -68,15 +68,15 @@ class NoClassifiedPostProcessorTestCase(unittest.TestCase):
                 [0.6, 0.2, 0.2, 0],
             ],
             index=[
-                "aid1",
-                "aid2",
-                "aid3",
-                "aid4",
-                "aid5",
+                "oid1",
+                "oid2",
+                "oid3",
+                "oid4",
+                "oid5",
             ],
             columns=["class1", "class2", "class3", "NotClassified"],
         )
-        expected_df.index.name = "aid"
+        expected_df.index.name = "oid"
 
         procesor = NoClassifiedPostProcessor(
             messages_df, complete_classifications_df
@@ -85,7 +85,7 @@ class NoClassifiedPostProcessorTestCase(unittest.TestCase):
 
         pd.testing.assert_frame_equal(result_df, expected_df)
 
-    def test_some_aid_not_classified(self):
+    def test_some_oid_not_classified(self):
         expected_df = pd.DataFrame(
             [
                 [0.1, 0.2, 0.7, 0],
@@ -95,15 +95,15 @@ class NoClassifiedPostProcessorTestCase(unittest.TestCase):
                 [0.6, 0.2, 0.2, 0],
             ],
             index=[
-                "aid1",
-                "aid2",
-                "aid3",
-                "aid4",
-                "aid5",
+                "oid1",
+                "oid2",
+                "oid3",
+                "oid4",
+                "oid5",
             ],
             columns=["class1", "class2", "class3", "NotClassified"],
         )
-        expected_df.index.name = "aid"
+        expected_df.index.name = "oid"
 
         procesor = NoClassifiedPostProcessor(
             messages_df, incomplete_classifications_df

--- a/schemas/feature_step/output.avsc
+++ b/schemas/feature_step/output.avsc
@@ -1,105 +1,100 @@
 {
-    "doc": "Multi stream light curve with xmatch",
-    "name": "alerce.light_curve_xmatched",
-    "type": "record",
-    "fields": [
-        {"name": "aid", "type": "string"},
-        {"name": "candid", "type": {"type": "array", "items": "string"}},
-        {"name": "meanra", "type": "float"},
-        {"name": "meandec", "type": "float"},
-        {
-            "name": "detections",
-            "type":
+  "doc": "Multi stream light curve with xmatch",
+  "name": "alerce.light_curve_xmatched",
+  "type": "record",
+  "fields": [
+    { "name": "oid", "type": "string" },
+    { "name": "candid", "type": { "type": "array", "items": "string" } },
+    { "name": "meanra", "type": "float" },
+    { "name": "meandec", "type": "float" },
+    {
+      "name": "detections",
+      "type": {
+        "type": "array",
+        "default": [],
+        "items": {
+          "name": "detections_record",
+          "type": "record",
+          "fields": [
+            { "name": "candid", "type": ["long", "string"] },
+            { "name": "tid", "type": "string" },
+            { "name": "aid", "type": "string" },
+            { "name": "oid", "type": ["long", "string"] },
+            { "name": "mjd", "type": "double" },
+            { "name": "sid", "type": "string" },
+            { "name": "fid", "type": "string" },
+            { "name": "pid", "type": "long" },
+            { "name": "ra", "type": "double" },
+            { "name": "e_ra", "type": "float" },
+            { "name": "dec", "type": "double" },
+            { "name": "e_dec", "type": "float" },
+            { "name": "mag", "type": "float" },
+            { "name": "e_mag", "type": "float" },
+            { "name": "mag_corr", "type": ["float", "null"] },
+            { "name": "e_mag_corr", "type": ["float", "null"] },
+            { "name": "e_mag_corr_ext", "type": ["float", "null"] },
+            { "name": "isdiffpos", "type": "int" },
+            { "name": "corrected", "type": "boolean" },
+            { "name": "dubious", "type": "boolean" },
+            { "name": "has_stamp", "type": "boolean" },
+            { "name": "stellar", "type": "boolean" },
+            { "name": "forced", "type": "boolean" },
+            { "name": "new", "type": "boolean" },
+            { "name": "parent_candid", "type": ["long", "string", "null"] },
             {
-                "type": "array",
-                "default": [],
-                "items": {
-                    "name": "detections_record",
-                    "type": "record",
-                    "fields": [
-                        {"name": "candid", "type": [ "long", "string" ]},
-                        {"name": "tid", "type": "string"},
-                        {"name": "aid", "type": "string"},
-                        {"name": "oid", "type": ["long", "string" ]},
-                        {"name": "mjd", "type": "double"},
-                        {"name": "sid", "type": "string"},
-                        {"name": "fid", "type": "string"},
-                        {"name": "pid", "type": "long"},
-                        {"name": "ra", "type": "double"},
-                        {"name": "e_ra", "type": "float"},
-                        {"name": "dec", "type": "double"},
-                        {"name": "e_dec", "type": "float"},
-                        {"name": "mag", "type": "float"},
-                        {"name": "e_mag", "type": "float"},
-                        {"name": "mag_corr", "type": ["float", "null"]},
-                        {"name": "e_mag_corr", "type": ["float", "null"]},
-                        {"name": "e_mag_corr_ext", "type": ["float", "null"]},
-                        {"name": "isdiffpos", "type": "int"},
-                        {"name": "corrected", "type": "boolean"},
-                        {"name": "dubious", "type": "boolean"},
-                        {"name": "has_stamp", "type": "boolean"},
-                        {"name": "stellar", "type": "boolean"},
-                        {"name": "forced", "type": "boolean"},
-                        {"name": "new", "type": "boolean"},
-                        {"name": "parent_candid", "type": ["long", "string", "null"]},
-                        {
-                            "name": "extra_fields",
-                            "type": {
-                                "default": {},
-                                "type": "map",
-                                "values": [
-                                    "null",
-                                    "int",
-                                    "float",
-                                    "string",
-                                    "bytes",
-                                    "boolean"
-                                ]
-                            }
-                        }
-                    ]
-                }
+              "name": "extra_fields",
+              "type": {
+                "default": {},
+                "type": "map",
+                "values": ["null", "int", "float", "string", "bytes", "boolean"]
+              }
             }
-        },
-        {
-            "name": "non_detections",
-            "type": {
-                "type": "array",
-                "default": [],
-                "items": {
-                    "name": "non_detections_record",
-                    "type": "record",
-                    "fields": [
-                        {"name": "aid", "type": "string"},
-                        {"name": "tid", "type": "string"},
-                        {"name": "sid", "type": "string"},
-                        {"name": "oid", "type": ["long", "string" ]},
-                        {"name": "mjd", "type": "double"},
-                        {"name": "fid", "type": "string"},
-                        {"name": "diffmaglim", "type": "float"}
-                    ]
-                }
-            }
-        },
-        {
-            "name": "xmatches",
-            "type": [
-                {
-                    "type": "map",
-                    "values": {"type": "map", "values": ["string", "float", "null", "int"]}
-                },
-                "null"
-            ]
-        },
-        {
-            "name": "features",
-            "type": [
-                {
-                    "type": "map",
-                    "values": ["boolean", "float", "null", "int"]
-                },
-                "null"
-            ]
+          ]
         }
-    ]
+      }
+    },
+    {
+      "name": "non_detections",
+      "type": {
+        "type": "array",
+        "default": [],
+        "items": {
+          "name": "non_detections_record",
+          "type": "record",
+          "fields": [
+            { "name": "aid", "type": "string" },
+            { "name": "tid", "type": "string" },
+            { "name": "sid", "type": "string" },
+            { "name": "oid", "type": ["long", "string"] },
+            { "name": "mjd", "type": "double" },
+            { "name": "fid", "type": "string" },
+            { "name": "diffmaglim", "type": "float" }
+          ]
+        }
+      }
+    },
+    {
+      "name": "xmatches",
+      "type": [
+        {
+          "type": "map",
+          "values": {
+            "type": "map",
+            "values": ["string", "float", "null", "int"]
+          }
+        },
+        "null"
+      ]
+    },
+    {
+      "name": "features",
+      "type": [
+        {
+          "type": "map",
+          "values": ["boolean", "float", "null", "int"]
+        },
+        "null"
+      ]
+    }
+  ]
 }

--- a/schemas/lc_classification_step/output_ztf.avsc
+++ b/schemas/lc_classification_step/output_ztf.avsc
@@ -1,52 +1,52 @@
 {
-    "doc": "Late Classification",
-    "name": "probabilities_and_features",
-    "type": "record",
-    "fields": [
-        {"name": "aid", "type": "string"},
+  "doc": "Late Classification",
+  "name": "probabilities_and_features",
+  "type": "record",
+  "fields": [
+    { "name": "oid", "type": "string" },
+    {
+      "name": "features",
+      "type": [
         {
-            "name": "features",
-            "type": [
-                {
-                    "type": "map",
-                    "values": ["boolean", "float", "null", "int"]
-                },
-                "null"
-            ]
+          "type": "map",
+          "values": ["boolean", "float", "null", "int"]
         },
-        {
-            "name": "lc_classification",
+        "null"
+      ]
+    },
+    {
+      "name": "lc_classification",
+      "type": {
+        "type": "record",
+        "name": "late_record",
+        "fields": [
+          {
+            "name": "probabilities",
             "type": {
-                "type": "record",
-                "name": "late_record",
-                "fields": [
-                    {
-                        "name": "probabilities",
-                        "type": {
-                            "type": "map",
-                            "values": ["float"]
-                        }
-                    },
-                    {"name": "class", "type": "string"},
-                    {
-                        "name": "hierarchical",
-                        "type": {
-                            "name": "root",
-                            "type": "map",
-                            "values": [
-                                {"type": "map", "values": "float"},
-                                {
-                                    "type": "map",
-                                    "values": {
-                                        "type": "map",
-                                        "values": "float"
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
+              "type": "map",
+              "values": ["float"]
             }
-        }
-    ]
+          },
+          { "name": "class", "type": "string" },
+          {
+            "name": "hierarchical",
+            "type": {
+              "name": "root",
+              "type": "map",
+              "values": [
+                { "type": "map", "values": "float" },
+                {
+                  "type": "map",
+                  "values": {
+                    "type": "map",
+                    "values": "float"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/xmatch_step/Dockerfile
+++ b/xmatch_step/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as python-base
+FROM python:3.10-slim as python-base
 LABEL org.opencontainers.image.authors="ALeRCE"
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -29,7 +29,7 @@ WORKDIR /app
 RUN poetry install --no-root --without=dev --without=test
 
 
-FROM python:3.7-slim as production
+FROM python:3.10-slim as production
 RUN pip install poetry
 
 COPY --from=builder /app /app

--- a/xmatch_step/poetry.lock
+++ b/xmatch_step/poetry.lock
@@ -547,7 +547,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "db-plugins"
-version = "6.1.1a66"
+version = "6.1.1a67"
 description = "ALeRCE database plugins."
 optional = false
 python-versions = ">=3.7, <3.12"

--- a/xmatch_step/xmatch_step/step.py
+++ b/xmatch_step/xmatch_step/step.py
@@ -1,16 +1,19 @@
 import json
 import time
 from typing import Dict, List, Tuple
+
 import pandas as pd
+from apf.consumers import KafkaConsumer
 from apf.core import get_class
 from apf.core.step import GenericStep
-from xmatch_step.core.xmatch_client import XmatchClient
+
+from xmatch_step.core.parsing import parse_output
 from xmatch_step.core.utils.constants import ALLWISE_MAP
 from xmatch_step.core.utils.extract_info import (
     extract_lightcurve_from_messages,
     get_candids_from_messages,
 )
-from xmatch_step.core.parsing import parse_output
+from xmatch_step.core.xmatch_client import XmatchClient
 
 
 class XmatchStep(GenericStep):
@@ -148,3 +151,10 @@ class XmatchStep(GenericStep):
         xmatches, lightcurves_by_oid, candids = result
         self.produce_scribe(xmatches)
         return xmatches, lightcurves_by_oid, candids
+
+    def tear_down(self):
+        if isinstance(self.consumer, KafkaConsumer):
+            self.consumer.teardown()
+        else:
+            self.consumer.__del__()
+        self.producer.__del__()


### PR DESCRIPTION
## Summary of the changes

- Uses oid instead of aid to group objects
- Update the elasticc models as well
- Refactor logging logic so that it only runs on errors


## If the change is BREAKING, please give more details about the breaking changes

- The grouping is now oid and not aid

#### Components that need updates and steps to follow

The alerce classifiers repo should be updated by merging [this PR](https://github.com/alercebroker/alerce_classifiers/pull/44), but after merging this one first.

## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.