### PR TITLE
fix: use oid, candid multiindex for detections and forced_photometry

### DIFF
--- a/libs/db-plugins/db_plugins/db/mongo/helpers/update_probs.py
+++ b/libs/db-plugins/db_plugins/db/mongo/helpers/update_probs.py
@@ -6,9 +6,9 @@ Helper function to create or update the probabilities for an object
 """
 
 
-def get_probabilities(database: Database, aids: list):
+def get_probabilities(database: Database, oids: list):
     probabilities = database["object"].find(
-        {"_id": {"$in": aids}}, {"probabilities": True}
+        {"_id": {"$in": oids}}, {"probabilities": True}
     )
     return {item["_id"]: item["probabilities"] for item in probabilities}
 
@@ -16,7 +16,7 @@ def get_probabilities(database: Database, aids: list):
 def get_db_operations(
     classifier: str,
     version: str,
-    aid: str,
+    oid: str,
     object_probabilities: list,
     probabilities: dict,
 ):
@@ -50,7 +50,7 @@ def get_db_operations(
     )
 
     operation = UpdateOne(
-        {"_id": aid}, {"$set": {"probabilities": object_probabilities}}
+        {"_id": oid}, {"$set": {"probabilities": object_probabilities}}
     )
 
     return operation
@@ -60,13 +60,17 @@ def create_or_update_probabilities(
     database: Database,
     classifier: str,
     version: str,
-    aid: str,
+    oids: str,
     probabilities: dict,
 ):
-    object_probs = get_probabilities(database, [aid])
+    object_probs = get_probabilities(database, [oids])
 
     database["object"].bulk_write(
-        [get_db_operations(classifier, version, aid, object_probs[aid], probabilities)],
+        [
+            get_db_operations(
+                classifier, version, oids, object_probs[oids], probabilities
+            )
+        ],
         ordered=False,
     )
 
@@ -75,7 +79,7 @@ def create_or_update_probabilities_bulk(
     database: Database,
     classifier: str,
     version: str,
-    aids: list,
+    oids: list,
     probabilities: list,
 ):
     """
@@ -83,13 +87,13 @@ def create_or_update_probabilities_bulk(
     """
     db_operations = []
 
-    # no warrants that probs will have the same aid order
-    object_probabilities = get_probabilities(database, aids)
+    # no warrants that probs will have the same oid order
+    object_probabilities = get_probabilities(database, oids)
 
-    for aid, probs in zip(aids, probabilities):
+    for oid, probs in zip(oids, probabilities):
         db_operations.append(
             get_db_operations(
-                classifier, version, aid, object_probabilities[aid], probs
+                classifier, version, oid, object_probabilities[oid], probs
             )
         )
 

--- a/libs/db-plugins/db_plugins/db/mongo/models.py
+++ b/libs/db-plugins/db_plugins/db/mongo/models.py
@@ -36,9 +36,9 @@ class Object(BaseModel):
     """
 
     _id = SpecialField(
-        lambda **kwargs: kwargs.get("aid") or kwargs["_id"]
-    )  # ALeRCE object ID (unique ID in database)
-    oid = Field()  # List with all OIDs
+        lambda **kwargs: kwargs.get("oid") or kwargs["_id"]
+    )  # Survey object ID (unique ID in database)
+    aid = Field()  # Alerce object ID (groups objects from different surveys)
     tid = Field()  # List with all telescopes the object has been observed with
     sid = Field()  # List with all surveys which their telescopes observed this obj
     corrected = Field()
@@ -63,9 +63,7 @@ class Object(BaseModel):
     xmatch = SpecialField(lambda **kwargs: kwargs.get("xmatch", []))
 
     __table_args__ = [
-        IndexModel([("oid", ASCENDING)], name="oid"),
-        IndexModel([("aid", ASCENDING)], name="aid"),
-        IndexModel([("sid", ASCENDING)], name="sid"),
+        IndexModel([("aid", ASCENDING), ("sid", ASCENDING)], name="aid"),
         IndexModel([("lastmjd", DESCENDING)], name="lastmjd"),
         IndexModel([("firstmjd", DESCENDING)], name="firstmjd"),
         IndexModel([("loc", GEOSPHERE)], name="radec"),
@@ -90,12 +88,12 @@ class Detection(BaseModelWithExtraFields):
         kwargs.pop("candid", None)  # Prevents candid being duplicated in extra_fields
         return kwargs
 
-    _id = SpecialField(lambda **kwargs: kwargs.get("candid") or kwargs["_id"])
     tid = Field()  # Telescope ID
     sid = Field()  # Survey ID
-    aid = Field()
+    aid = Field()  # object alerce identifier
     pid = Field()
-    oid = Field()
+    oid = Field()  # object survey identifier
+    candid = Field()  # alert identifier
     mjd = Field()
     fid = Field()
     ra = Field()
@@ -114,9 +112,8 @@ class Detection(BaseModelWithExtraFields):
     has_stamp = Field()
 
     __table_args__ = [
-        IndexModel([("oid", ASCENDING)]),
-        IndexModel([("aid", ASCENDING)]),
-        IndexModel([("sid", ASCENDING)]),
+        IndexModel([("aid", ASCENDING), ("sid", ASCENDING)]),
+        IndexModel([("candid", ASCENDING), ("oid", ASCENDING)], unique=True),
     ]
     __tablename__ = "detection"
 
@@ -128,7 +125,6 @@ class ForcedPhotometry(BaseModelWithExtraFields):
         kwargs.pop("candid", None)  # Prevents candid being duplicated in extra_fields
         return kwargs
 
-    _id = SpecialField(lambda **kwargs: kwargs.get("candid") or kwargs["_id"])
     tid = Field()  # Telescope ID
     sid = Field()  # Survey ID
     aid = Field()
@@ -152,9 +148,8 @@ class ForcedPhotometry(BaseModelWithExtraFields):
     has_stamp = Field()
 
     __table_args__ = [
-        IndexModel([("oid", ASCENDING)], name="oid"),
-        IndexModel([("aid", ASCENDING)], name="aid"),
-        IndexModel([("sid", ASCENDING)], name="sid"),
+        IndexModel([("oid", ASCENDING), ("sid", ASCENDING)]),
+        IndexModel([("pid", ASCENDING), ("oid", ASCENDING)], unique=True),
     ]
     __tablename__ = "forced_photometry"
 
@@ -166,7 +161,6 @@ class NonDetection(BaseModelWithExtraFields):
         kwargs.pop("candid", None)  # Prevents candid being duplicated in extra_fields
         return kwargs
 
-    _id = SpecialField(lambda **kwargs: kwargs.get("candid") or kwargs["_id"])
     aid = Field()
     tid = Field()
     sid = Field()
@@ -184,17 +178,3 @@ class NonDetection(BaseModelWithExtraFields):
         IndexModel([("sid", ASCENDING)], name="sid"),
     ]
     __tablename__ = "non_detection"
-
-
-class Taxonomy(BaseModel):
-    classifier_name = Field()
-    classifier_version = Field()
-    classes = Field()
-
-    __table_args__ = [
-        IndexModel(
-            [("classifier_name", ASCENDING), ("classifier_version", DESCENDING)],
-            name="name_version",
-        ),
-    ]
-    __tablename__ = "taxonomy"

--- a/libs/db-plugins/tests/unittest/db/test_helpers.py
+++ b/libs/db-plugins/tests/unittest/db/test_helpers.py
@@ -33,8 +33,8 @@ class TestMongoProbabilities(unittest.TestCase):
 
     def create_2_objects(self):
         model_1 = Object(
-            _id="aid1",
-            oid="oid1",
+            _id="oid1",
+            aid="aid1",
             sid="sid",
             tid="tid1",
             corrected=False,
@@ -79,8 +79,8 @@ class TestMongoProbabilities(unittest.TestCase):
             ],
         )
         model_2 = Object(
-            _id="aid2",
-            oid="oid2",
+            _id="oid2",
+            aid="aid2",
             sid="sid",
             tid="tid2",
             corrected=False,
@@ -119,14 +119,14 @@ class TestMongoProbabilities(unittest.TestCase):
             self.mongo_connection.database,
             "stamp_classifier",
             "stamp_classifier_1.0.0",
-            "aid2",
+            "oid2",
             {
                 "CLASS1": 0.3,
                 "CLASS2": 0.7,
             },
         )
 
-        f1 = self.obj_collection.find_one({"_id": "aid2"})
+        f1 = self.obj_collection.find_one({"_id": "oid2"})
 
         expected_probabilities = [
             {
@@ -168,14 +168,14 @@ class TestMongoProbabilities(unittest.TestCase):
             self.mongo_connection.database,
             "stamp_classifier",
             "stamp_classifier_1.0.0",
-            "aid1",
+            "oid1",
             {
                 "CLASS1": 0.3,
                 "CLASS2": 0.7,
             },
         )
 
-        f1 = self.obj_collection.find_one({"_id": "aid1"})
+        f1 = self.obj_collection.find_one({"_id": "oid1"})
 
         # Mind that the update don't change the order
         expected_probabilities = [
@@ -218,7 +218,7 @@ class TestMongoProbabilities(unittest.TestCase):
             self.mongo_connection.database,
             "stamp_classifier",
             "stamp_classifier_1.0.0",
-            ["aid1", "aid2"],
+            ["oid1", "oid2"],
             [
                 {
                     "CLASS1": 0.3,
@@ -231,8 +231,8 @@ class TestMongoProbabilities(unittest.TestCase):
             ],
         )
 
-        f1 = self.obj_collection.find_one({"_id": "aid1"})
-        f2 = self.obj_collection.find_one({"_id": "aid2"})
+        f1 = self.obj_collection.find_one({"_id": "oid1"})
+        f2 = self.obj_collection.find_one({"_id": "oid2"})
 
         expected_probabilities_1 = [
             {

--- a/libs/db-plugins/tests/unittest/db/test_mongo.py
+++ b/libs/db-plugins/tests/unittest/db/test_mongo.py
@@ -46,7 +46,6 @@ class MongoConnectionTest(unittest.TestCase):
             "detection",
             "forced_photometry",
             "non_detection",
-            "taxonomy",
         ]
         self.assertEqual(collections, expected)
 

--- a/libs/db-plugins/tests/unittest/db/test_mongo_models.py
+++ b/libs/db-plugins/tests/unittest/db/test_mongo_models.py
@@ -208,29 +208,3 @@ class MongoModelsTest(unittest.TestCase):
             extra_fields={"extra": "extra"},
         )
         self.assertEqual(o["extra_fields"], {"extra": "extra"})
-
-    def test_taxonomy_creates(self):
-        o = models.Taxonomy(
-            classifier_name="classifier",
-            classifier_version="test-1.0.0",
-            classes=["class1", "class2"],
-        )
-        self.assertIsInstance(o, models.Taxonomy)
-        self.assertIsInstance(o, dict)
-        self.assertEqual(o["classifier_name"], "classifier")
-
-    def test_taxonomy_fails_creation(self):
-        with self.assertRaises(AttributeError) as e:
-            models.Taxonomy()
-        self.assertEqual(
-            str(e.exception), "Taxonomy model needs classifier_name attribute"
-        )
-
-    def test_taxonomy_with_extra_fields_ignores_them(self):
-        as_dict = dict(
-            classifier_name="classifier",
-            classifier_version="test-1.0.0",
-            classes=["class1", "class2"],
-        )
-        o = models.Taxonomy(extra="extra", **as_dict)
-        self.assertDictEqual(o, as_dict)

--- a/libs/db-plugins/tests/unittest/db/test_probabilities.py
+++ b/libs/db-plugins/tests/unittest/db/test_probabilities.py
@@ -121,7 +121,7 @@ class MongoProbabilitiesTest(unittest.TestCase):
         fl = list(f)
         self.assertIsNotNone(f)
         self.assertEqual(len(fl), 1)
-        self.assertEqual(fl[0]["_id"], "aid1")
+        self.assertEqual(fl[0]["_id"], "oid1")
 
         # find object 2
         f = self.obj_collection.find(
@@ -140,7 +140,7 @@ class MongoProbabilitiesTest(unittest.TestCase):
         fl = list(f)
         self.assertIsNotNone(f)
         self.assertEqual(len(fl), 1)
-        self.assertEqual(fl[0]["_id"], "aid2")
+        self.assertEqual(fl[0]["_id"], "oid2")
 
     def test_query_with_probabilities_find_none(self):
         self.create_2_objects()
@@ -185,14 +185,14 @@ class MongoProbabilitiesTest(unittest.TestCase):
     def test_update_probability(self):
         """
         According to my documentation reading, to update an object we must first check if the
-        probability we desire to update exist (a filter for the aid and a elemMatch for the probabilitie).
+        probability we desire to update exist (a filter for the oid and a elemMatch for the probabilitie).
         If it does we can update it, if it doesn't we need to push it.
         """
         self.create_2_objects()
 
         self.obj_collection.update_one(
             {
-                "_id": "aid1",
+                "_id": "oid1",
                 "probabilities": {
                     "$elemMatch": {
                         "classifier_name": "stamp_classifier",
@@ -204,7 +204,7 @@ class MongoProbabilitiesTest(unittest.TestCase):
             {"$set": {"probabilities.$.probability": 1.0}},
         )
 
-        f1 = self.obj_collection.find_one({"_id": "aid1"})
+        f1 = self.obj_collection.find_one({"_id": "oid1"})
         expected_object_1_probabilities = [
             {
                 "classifier_name": "stamp_classifier",
@@ -223,7 +223,7 @@ class MongoProbabilitiesTest(unittest.TestCase):
         ]
         self.assertEqual(f1["probabilities"], expected_object_1_probabilities)
 
-        f2 = self.obj_collection.find_one({"_id": "aid2"})
+        f2 = self.obj_collection.find_one({"_id": "oid2"})
         expected_object_2_probabilities = [
             {
                 "classifier_name": "stamp_classifier",
@@ -250,7 +250,7 @@ class MongoProbabilitiesTest(unittest.TestCase):
 
         self.obj_collection.update_one(
             {
-                "_id": "aid3",
+                "_id": "oid3",
             },
             {
                 "$push": {
@@ -265,7 +265,7 @@ class MongoProbabilitiesTest(unittest.TestCase):
             },
         )
 
-        f = self.obj_collection.find_one({"_id": "aid3"})
+        f = self.obj_collection.find_one({"_id": "oid3"})
         expected_object_probabilities = [
             {
                 "classifier_name": "stamp_classifier",

--- a/scribe/mongo_scribe/sql/command/commands.py
+++ b/scribe/mongo_scribe/sql/command/commands.py
@@ -115,7 +115,7 @@ class InsertDetectionsCommand(Command):
         )
         new_data["fid"] = fid_map[new_data["fid"]]
 
-        return {**new_data, "candid": int(self.criteria["_id"])}
+        return {**new_data, **self.criteria}
 
     @staticmethod
     def db_operation(session: Session, data: List):

--- a/scribe/tests/integration/test_step_sql.py
+++ b/scribe/tests/integration/test_step_sql.py
@@ -128,7 +128,7 @@ class PsqlIntegrationTest(unittest.TestCase):
             {
                 "collection": "detection",
                 "type": "update",
-                "criteria": {"_id": "932472823"},
+                "criteria": {"candid": "932472823", "oid": "ZTF04ululeea"},
                 "data": {
                     "aid": "XChGbTDJWt",
                     "corrected": False,
@@ -602,7 +602,8 @@ class PsqlIntegrationTest(unittest.TestCase):
                 "collection": "forced_photometry",
                 "type": "update",
                 "criteria": {
-                    "_id": "candid-pid",
+                    "oid": "ZTF04ululeea",
+                    "candid": "ZTF04ululeea423432",
                 },
                 "data": {
                     "mag": 10.0,

--- a/sorting_hat_step/sorting_hat_step/utils/database.py
+++ b/sorting_hat_step/sorting_hat_step/utils/database.py
@@ -19,7 +19,7 @@ def oid_query(db: MongoConnection, oid: list) -> Union[str, None]:
 
     :return: existing aid if exists else is None
     """
-    found = db.database["object"].find_one({"oid": {"$in": oid}}, {"_id": 1})
+    found = db.database["object"].find_one({"_id": {"$in": oid}}, {"_id": 1})
     if found:
         return found["_id"]
     return None

--- a/sorting_hat_step/tests/unittest/test_database.py
+++ b/sorting_hat_step/tests/unittest/test_database.py
@@ -18,7 +18,7 @@ class DatabaseTestCase(unittest.TestCase):
         aid = database.oid_query(self.mock_db, ["x", "y", "z"])
         self.assertEqual(aid, 1)
         self.mock_db.database["object"].find_one.assert_called_with(
-            {"oid": {"$in": ["x", "y", "z"]}}, {"_id": 1}
+            {"_id": {"$in": ["x", "y", "z"]}}, {"_id": 1}
         )
 
     def test_oid_query_with_no_elements(self):


### PR DESCRIPTION
-------

## Summary of the changes

Update models to use oid, candid as index on detection.


## Observations

THIS PR needs changes on the steps that drop duplicates by candid. Work by @AlxEnashi.


## If the change is BREAKING, please give more details about the breaking changes

The mongo models no longer use candid as `_id` on detection collection. The candid will be a field in the document and there is an unique index added to candid + oid.

#### Components that need updates and steps to follow

Prv candidates step, correction step and lightcurve step need to be verified to not drop by candid.
Also the scribe criteria needs to be fixed on the correction step. (see scribe tests on this PR)
Steps that read detections from database (e.g Lightcurve Step) need to read candid from a field rather than from `_id`

## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.