### PR TITLE
Refactor: mongo db function return "_id" this is the oid, should return aid

### DIFF
--- a/sorting_hat_step/sorting_hat_step/utils/database.py
+++ b/sorting_hat_step/sorting_hat_step/utils/database.py
@@ -19,9 +19,9 @@ def oid_query(db: MongoConnection, oid: list) -> Union[str, None]:
 
     :return: existing aid if exists else is None
     """
-    found = db.database["object"].find_one({"_id": {"$in": oid}}, {"_id": 1})
+    found = db.database["object"].find_one({"_id": {"$in": oid}}, {"aid": 1})
     if found:
-        return found["_id"]
+        return found["aid"]
     return None
 
 
@@ -51,10 +51,11 @@ def conesearch_query(
                 },
             },
         },
-        {"_id": 1},
+        {"aid": 1},
     )
     if found:
-        return found["_id"]
+        print(found)
+        return found["aid"]
     return None
 
 

--- a/sorting_hat_step/tests/unittest/test_database.py
+++ b/sorting_hat_step/tests/unittest/test_database.py
@@ -14,11 +14,11 @@ class DatabaseTestCase(unittest.TestCase):
 
     def test_oid_query(self):
         # Mock a response with elements in database
-        self.mock_db.database["object"].find_one.return_value = {"_id": 1}
+        self.mock_db.database["object"].find_one.return_value = {"_id": 1, "aid": 1}
         aid = database.oid_query(self.mock_db, ["x", "y", "z"])
         self.assertEqual(aid, 1)
         self.mock_db.database["object"].find_one.assert_called_with(
-            {"_id": {"$in": ["x", "y", "z"]}}, {"_id": 1}
+            {"_id": {"$in": ["x", "y", "z"]}}, {"aid": 1}
         )
 
     def test_oid_query_with_no_elements(self):
@@ -31,11 +31,11 @@ class DatabaseTestCase(unittest.TestCase):
             "field1": 1,
             "field2": 2,
         }
-        with self.assertRaisesRegex(KeyError, "_id"):
+        with self.assertRaisesRegex(KeyError, "aid"):
             database.oid_query(self.mock_db, ["x", "y", "z"])
 
     def test_conesearch_query(self):
-        self.mock_db.database["object"].find_one.return_value = {"_id": 1}
+        self.mock_db.database["object"].find_one.return_value = {"_id": 1, "aid": 1}
         aid = database.conesearch_query(
             self.mock_db, 180, 0, math.degrees(3600)
         )
@@ -49,7 +49,7 @@ class DatabaseTestCase(unittest.TestCase):
                     },
                 },
             },
-            {"_id": 1},  # only return alerce_id
+            {"aid": 1},
         )
 
     def test_conesearch_query_without_results(self):


### PR DESCRIPTION
## Summary of the changes

Changed mongo db quertys return from _id to aid, the _id is the oid and aid is the required value.
Fixed tests.


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.

