### PR TITLE
Adding update object to the scribe

### DIFF
--- a/scribe/mongo_scribe/sql/command/commands.py
+++ b/scribe/mongo_scribe/sql/command/commands.py
@@ -55,6 +55,52 @@ class InsertObjectCommand(Command):
             insert(Object).values(data).on_conflict_do_nothing()
         )
 
+class UpdateObjectCommand(Command):
+    type = ValidCommands.update_object
+    valid_attributes = set([
+        "ndethist",
+        "ncovhist",
+        "mjdstarthist",
+        "mjdendhist",
+        "corrected",
+        "stellar",
+        "ndet",
+        "g_r_max",
+        "g_r_max_corr",
+        "g_r_mean",
+        "g_r_mean_corr",
+        "meanra",
+        "meandec",
+        "sigmara",
+        "sigmadec",
+        "deltajd",
+        "firstmjd",
+        "lastmjd",
+        "step_id_corr", 
+        "diffpos",
+    ])
+
+    def _check_inputs(self, data, criteria):
+        super()._check_inputs(data, criteria)
+
+        if not set(data.keys()).issubset(self.valid_attributes):
+            bad_inputs = set(data.keys()).difference(self.valid_attributes)
+            raise ValueError(f"Invalid keys provided {bad_inputs}")
+        
+    def _format_data(self, data):
+        return {
+            "oid": self.criteria["oid"],
+            **data
+        }
+    
+    @staticmethod
+    def db_operation(session: Session, data: List):
+        print("\n...........\n object\n")
+        #upsert_stmt = update(Object)
+        logging.debug("Updating or inserting %s objects", len(data))
+        return session.bulk_update_mappings(
+            Object, data
+        )
 
 class InsertDetectionsCommand(Command):
     type = ValidCommands.insert_detections
@@ -332,6 +378,7 @@ class UpsertXmatchCommand(Command):
 
     @staticmethod
     def db_operation(session: Session, data: list):
+        print("\n...........\nxmatch\n")
         unique = {(d["oid"], d["catid"]): d for d in data}
         unique = list(unique.values())
         insert_stmt = insert(Xmatch)

--- a/scribe/mongo_scribe/sql/command/commands.py
+++ b/scribe/mongo_scribe/sql/command/commands.py
@@ -95,7 +95,6 @@ class UpdateObjectCommand(Command):
     
     @staticmethod
     def db_operation(session: Session, data: List):
-        print("\n...........\n object\n")
         #upsert_stmt = update(Object)
         logging.debug("Updating or inserting %s objects", len(data))
         return session.bulk_update_mappings(
@@ -378,7 +377,6 @@ class UpsertXmatchCommand(Command):
 
     @staticmethod
     def db_operation(session: Session, data: list):
-        print("\n...........\nxmatch\n")
         unique = {(d["oid"], d["catid"]): d for d in data}
         unique = list(unique.values())
         insert_stmt = insert(Xmatch)

--- a/scribe/mongo_scribe/sql/command/commons.py
+++ b/scribe/mongo_scribe/sql/command/commons.py
@@ -5,6 +5,8 @@
 class ValidCommands:
     # insert + object
     insert_object = "insert_object"
+    #update + object no xmatch in data
+    update_object = "update_object"
     # update + detections
     insert_detections = "insert_detections"
     # update_probabilities + probabilities in data

--- a/scribe/mongo_scribe/sql/command/decode.py
+++ b/scribe/mongo_scribe/sql/command/decode.py
@@ -3,6 +3,7 @@ from .exceptions import WrongFormatCommandException
 from .commands import (
     Command,
     InsertObjectCommand,
+    UpdateObjectCommand,
     InsertDetectionsCommand,
     InsertForcedPhotometryCommand,
     UpdateObjectStatsCommand,
@@ -49,6 +50,8 @@ def command_factory(msg: str) -> Command:
     # here it comes
     if type_ == "insert" and table == "object":
         return InsertObjectCommand(**message)
+    if type_ == "update" and table == "object" and "xmatch" not in message["data"]:
+        return UpdateObjectCommand(**message)
     if type_ == "update" and table == "detection":
         return InsertDetectionsCommand(**message)
     if type_ == "upsert" and table == "magstats":

--- a/scribe/mongo_scribe/sql/db/executor.py
+++ b/scribe/mongo_scribe/sql/db/executor.py
@@ -5,6 +5,7 @@ from .connection import PSQLConnection, Session
 from mongo_scribe.sql.command.commands import (
     Command,
     InsertObjectCommand,
+    UpdateObjectCommand,
     InsertDetectionsCommand,
     InsertForcedPhotometryCommand,
     UpdateObjectStatsCommand,
@@ -41,6 +42,7 @@ class SQLCommandExecutor:
         self.connection = PSQLConnection(config["PSQL"])
         commands = (
             InsertObjectCommand,
+            UpdateObjectCommand,
             InsertDetectionsCommand,
             InsertForcedPhotometryCommand,
             UpdateObjectStatsCommand,


### PR DESCRIPTION
## Summary of the changes

Added update object command to the sql commands, added the decoder and make it different from the upsertxmatch command. Added integration test for the sql scribe.


## Observations

As far as I understand it the mongo scribe is flexible enough to support the update object use case.
There isnt integration tests tho. 
In the topics of tests, there are not unit tests for sql scribe.

Maybe shuold starts sql unitests and mongo integration fot this command.

## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.
