### PR TITLE
Remove reference key from messages after computing features

### DIFF
--- a/feature_step/features/step.py
+++ b/feature_step/features/step.py
@@ -133,6 +133,10 @@ class FeatureStep(GenericStep):
 
     def post_execute(self, result):
         self.metrics["sid"] = get_sid(result)
+
+        for message in result:
+            del message["reference"]
+
         return result
 
     def tear_down(self):

--- a/feature_step/tests/unittest/test_step.py
+++ b/feature_step/tests/unittest/test_step.py
@@ -205,3 +205,11 @@ class StepTestCase(unittest.TestCase):
             pd.DataFrame(_get_sql_ref.return_value)[columns].set_index("rfid"),
             check_like=True,
         )
+
+    def test_post_execute(self):
+        messages = generate_input_batch(10, ["g", "r"], survey="ZTF")
+        result_messages = self.step.execute(messages)
+        result_messages = self.step.post_execute(result_messages)
+
+        for message in result_messages:
+            self.assertTrue("reference" not in message.keys())


### PR DESCRIPTION
The "reference" key is now removed from messages in feature step in post execute, as it is not needed anymore in the pipeline