### PR TITLE
Fix/top bottom parser lc classifier

### DIFF
--- a/lc_classification_step/lc_classification/core/parsers/scribe_parser.py
+++ b/lc_classification_step/lc_classification/core/parsers/scribe_parser.py
@@ -299,7 +299,9 @@ class TopBottomScribeParser(KafkaParser):
         hierarchical = pd.DataFrame()
         for ch in to_parse.hierarchical["children"].keys():
             hierarchical_ch = to_parse.hierarchical["children"][ch]
-            hierarchical_ch["classifier_name"] = self._get_classifier_name(ch.lower())
+            hierarchical_ch["classifier_name"] = self._get_classifier_name(
+                ch.lower()
+            )
             hierarchical = pd.concat([hierarchical, hierarchical_ch], axis=0)
 
         # probabilities

--- a/lc_classification_step/lc_classification/core/parsers/scribe_parser.py
+++ b/lc_classification_step/lc_classification/core/parsers/scribe_parser.py
@@ -292,14 +292,15 @@ class TopBottomScribeParser(KafkaParser):
             return KafkaOutput([])
         probabilities = to_parse.probabilities
         top = to_parse.hierarchical["top"]
-        hierarchical = [
-            to_parse.hierarchical["children"][ch]
-            for ch in to_parse.hierarchical["children"].keys()
-        ]
-        hierarchical = pd.concat(hierarchical)
+
         probabilities["classifier_name"] = self._get_classifier_name()
         top["classifier_name"] = self._get_classifier_name("top")
-        hierarchical["classifier_name"] = self._get_classifier_name("bottom")
+
+        hierarchical = pd.DataFrame()
+        for ch in to_parse.hierarchical["children"].keys():
+            hierarchical_ch = to_parse.hierarchical["children"][ch]
+            hierarchical_ch["classifier_name"] = self._get_classifier_name(ch)
+            hierarchical = pd.concat([hierarchical, hierarchical_ch], axis=0)
 
         # probabilities
         if not probabilities.index.name == "oid":

--- a/lc_classification_step/lc_classification/core/parsers/scribe_parser.py
+++ b/lc_classification_step/lc_classification/core/parsers/scribe_parser.py
@@ -299,7 +299,7 @@ class TopBottomScribeParser(KafkaParser):
         hierarchical = pd.DataFrame()
         for ch in to_parse.hierarchical["children"].keys():
             hierarchical_ch = to_parse.hierarchical["children"][ch]
-            hierarchical_ch["classifier_name"] = self._get_classifier_name(ch)
+            hierarchical_ch["classifier_name"] = self._get_classifier_name(ch.lower())
             hierarchical = pd.concat([hierarchical, hierarchical_ch], axis=0)
 
         # probabilities


### PR DESCRIPTION
## Summary of the changes

All random forest bottom classifiers have the same name (classifier_bottom), but they should be classifier_transient, classifier_stochastic and classifier_periodic. This PR solves that


## Observations

<-- Add some notes to keep in mind !-->


## If the change is BREAKING, please give more details about the breaking changes

<-- What change breaks what and how !-->

#### Components that need updates and steps to follow

<-- Link repos or other PRs !-->


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->