### PR TITLE
Feature enhancements

### DIFF
--- a/lc_classifier/lc_classifier/features/extractors/tde_extractor.py
+++ b/lc_classifier/lc_classifier/features/extractors/tde_extractor.py
@@ -128,7 +128,7 @@ def fleet_model_jax(t, a, w, m_0, t0):
 
 
 class FleetExtractor(FeatureExtractor):
-    version = "1.0.1"
+    version = "1.0.2"
     unit = "diff_flux"
 
     def __init__(self, bands: List[str]):
@@ -180,6 +180,7 @@ class FleetExtractor(FeatureExtractor):
                     sigma=y_err,
                     p0=[0.6, -0.05, np.mean(y), 0],
                     bounds=([0.0, -100.0, 0, -50], [10, 0, 30, 10000]),
+                    max_nfev=800,  # twice default value
                 )
 
                 model_prediction = fleet_model(

--- a/lc_classifier/lc_classifier/features/extractors/ulens_extractor.py
+++ b/lc_classifier/lc_classifier/features/extractors/ulens_extractor.py
@@ -39,7 +39,7 @@ def ulens_model_jax(t, u0, tE, fs, t0, mag_0):
 
 
 class MicroLensExtractor(FeatureExtractor):
-    version = "1.0.1"
+    version = "1.0.2"
     unit = "magnitude"
 
     def __init__(self, bands: List[str]):
@@ -88,6 +88,7 @@ class MicroLensExtractor(FeatureExtractor):
                         [0, 0, 0, -np.inf, -np.inf],
                         [np.inf, np.inf, 1, np.inf, np.inf],
                     ),
+                    max_nfev=1000,  # twice default value
                 )
 
                 model_prediction = ulens_model(band_observations["mjd"], *parameters)

--- a/training/lc_classifier_ztf/feature_computation/dataset.py
+++ b/training/lc_classifier_ztf/feature_computation/dataset.py
@@ -21,7 +21,10 @@ def create_astro_object(lc_df: pd.DataFrame, object_info: pd.Series) -> AstroObj
                  inplace=True)
 
     lc_df["fid"] = lc_df["fid"].map({1: "g", 2: "r", 3: "i"})
-    lc_df = lc_df[lc_df["fid"].isin(["g", "r"])]
+    lc_df["procstatus"] = lc_df["procstatus"].astype(str)
+    
+    lc_df = lc_df[lc_df["fid"].isin(["g", "r"]) \
+                  & (lc_df["procstatus"] == "0")]
 
     if len(lc_df[lc_df["detected"]]) == 0:
         raise NoDetections()
@@ -99,13 +102,13 @@ def create_astro_object(lc_df: pd.DataFrame, object_info: pd.Series) -> AstroObj
 if __name__ == "__main__":
     # Build AstroObjects
 
-    data_dir = "data_241015"
+    data_dir = "data_241209"
     data_out = data_dir + "_ao"
     lightcurve_filenames = os.listdir(data_dir)
     lightcurve_filenames = [f for f in lightcurve_filenames if "lightcurves_batch" in f]
 
     object_df = pd.read_parquet(
-        os.path.join(data_dir, "objects_with_wise_20241016.parquet")
+        os.path.join(data_dir, "objects_with_wise_20241209.parquet")
     )
     object_df.set_index("oid", inplace=True)
 


### PR DESCRIPTION
## Summary of the changes

This PR:
- For the training set, adds a procstatus criterion for selecting light curve epochs that go into astro_objects: only epochs with procstatus='0' are kept. This means an extra cleaning for the light curves that will be used in feature computation and classifiers, removing noisier epochs.
- For ulens and fleet extractors, changes the maximum number of function evaluations used in least_squares (passed through curve_fit). As the default value is given by 100*(number of free parameters), now twice this value will be used. This change is done because in the non-labeled set many objects with large ndet got nan features, that became not nan values after increasing max_nfev.


## Observations

Before passing to production, models should be trained including these changes, and the procstatus criterion must be implemented in the pipeline.


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [X] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.