### PR TITLE
Added procstatus='57' as valid in training

### DIFF
--- a/training/lc_classifier_ztf/feature_computation/dataset.py
+++ b/training/lc_classifier_ztf/feature_computation/dataset.py
@@ -24,7 +24,8 @@ def create_astro_object(lc_df: pd.DataFrame, object_info: pd.Series) -> AstroObj
     lc_df["procstatus"] = lc_df["procstatus"].astype(str)
     
     lc_df = lc_df[lc_df["fid"].isin(["g", "r"]) \
-                  & (lc_df["procstatus"] == "0")]
+                  & ((lc_df["procstatus"] == "0") \
+                      | (lc_df["procstatus"] == "57"))]
 
     if len(lc_df[lc_df["detected"]]) == 0:
         raise NoDetections()


### PR DESCRIPTION
## Summary of the changes

For the training set, adds an extra procstatus criterion for selecting light curve epochs that go into astro_objects: only epochs with procstatus='0' or '57' are kept. '57' means "No reference-image-catalog source within 5 arcsec".


## Observations

Before passing to production, models should be trained including this change, and the procstatus criteria must be implemented in the pipeline.