### PR TITLE
Added ZTF preprocessor that shortens light curves in ndet

### DIFF
--- a/lc_classifier/lc_classifier/features/preprocess/ztf.py
+++ b/lc_classifier/lc_classifier/features/preprocess/ztf.py
@@ -84,3 +84,23 @@ class ShortenPreprocessor(LightcurvePreprocessor):
         astro_object.forced_photometry = astro_object.forced_photometry[
             astro_object.forced_photometry["mjd"] < last_detection_mjd
         ]
+
+
+class ShortenNDetPreprocessor(LightcurvePreprocessor):
+    def __init__(self, n_dets: float):
+        self.n_dets = n_dets
+
+    def preprocess_single_object(self, astro_object: AstroObject):
+        dets = astro_object.detections[
+            astro_object.detections["unit"] == "diff_flux"
+        ].copy()
+        dets = dets.sort_values(by="mjd").iloc[0 : self.n_dets].copy()
+        max_mjd = np.max(dets["mjd"])
+        del dets
+
+        astro_object.detections = astro_object.detections[
+            astro_object.detections["mjd"] <= max_mjd
+        ]
+        astro_object.forced_photometry = astro_object.forced_photometry[
+            astro_object.forced_photometry["mjd"] < max_mjd
+        ]


### PR DESCRIPTION
## Summary of the changes

Added a ZTF preprocessor that shortens light curves in a given number of detections. This is useful for test set evaluations.


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [X] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.