### PR TITLE
Use ndet>=8 in training set

### DIFF
--- a/feature_step/settings.py
+++ b/feature_step/settings.py
@@ -123,4 +123,5 @@ STEP_CONFIG = {
     "PYROSCOPE_SERVER": pyroscope_server,
     "SQL_SECRET_NAME": os.getenv("SQL_SECRET_NAME"),
     "PSQL_CONFIG": PSQL_CONFIG,
+    "MIN_DETECTIONS_FEATURES": os.getenv("MIN_DETECTIONS_FEATURES", None),
 }

--- a/feature_step/tests/unittest/test_step.py
+++ b/feature_step/tests/unittest/test_step.py
@@ -119,6 +119,31 @@ class StepTestCase(unittest.TestCase):
 
         assert multiband_period_scribe == multiband_period_message
 
+    def test_pre_execute(self):
+        step_config = {
+            "PRODUCER_CONFIG": PRODUCER_CONFIG,
+            "CONSUMER_CONFIG": CONSUMER_CONFIG,
+            "SCRIBE_PRODUCER_CONFIG": SCRIBE_PRODUCER_CONFIG,
+            "FEATURE_VERSION": "v1",
+            "STEP_METADATA": {
+                "STEP_VERSION": "feature",
+                "STEP_ID": "feature",
+                "STEP_NAME": "feature",
+                "STEP_COMMENTS": "feature",
+                "FEATURE_VERSION": "1.0-test",
+            },
+            "MIN_DETECTIONS_FEATURES": 2,
+        }
+        db_sql = mock.MagicMock()
+        step = FeatureStep(config=step_config, db_sql=db_sql)
+        step.scribe_producer = mock.create_autospec(GenericProducer)
+        step.scribe_producer.produce = mock.MagicMock()
+
+        messages = [spm_messages[2]]  # has only 1 detection
+        result_messages = step.pre_execute(messages)
+
+        self.assertEqual(0, len(result_messages))
+
     def test_drop_bogus(self):
         messages = [
             spm_messages[2]

--- a/training/lc_classifier_ztf/feature_computation/dataset.py
+++ b/training/lc_classifier_ztf/feature_computation/dataset.py
@@ -6,6 +6,9 @@ from lc_classifier.features.core.base import AstroObject, save_astro_objects_bat
 from tqdm import tqdm
 
 
+NDET_MIN = 8
+
+
 class NoDetections(Exception):
     pass
 
@@ -27,7 +30,7 @@ def create_astro_object(lc_df: pd.DataFrame, object_info: pd.Series) -> AstroObj
                   & ((lc_df["procstatus"] == "0") \
                      | (lc_df["procstatus"] == "57"))]
 
-    if len(lc_df[lc_df["detected"]]) < 2:
+    if len(lc_df[lc_df["detected"]]) < NDET_MIN:
         raise NoDetections()
 
     diff_flux = lc_df[
@@ -104,7 +107,7 @@ if __name__ == "__main__":
     # Build AstroObjects
 
     data_dir = "data_241209"
-    data_out = data_dir + "_ao"
+    data_out = data_dir + "_ndetge" + str(NDET_MIN) + "_ao"
     lightcurve_filenames = os.listdir(data_dir)
     lightcurve_filenames = [f for f in lightcurve_filenames if "lightcurves_batch" in f]
 


### PR DESCRIPTION
## Summary of the changes

Changed the threshold in minimum number of detections from 2 to 8, for training set objects.

## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.