### PR TITLE
Added control of nans in WISE extractor

### DIFF
--- a/feature_step/tests/unittest/test_step.py
+++ b/feature_step/tests/unittest/test_step.py
@@ -180,7 +180,6 @@ class StepTestCase(unittest.TestCase):
         ]  # after drop bogus detections, it ends with 0 detections
         result_messages = step.execute(messages)
         result_messages = step.post_execute(result_messages)
-        print(result_messages)
 
         self.assertEqual(len(messages), len(result_messages))
         n_features_prev = -1

--- a/lc_classifier/lc_classifier/features/extractors/allwise_colors_feature_extractor.py
+++ b/lc_classifier/lc_classifier/features/extractors/allwise_colors_feature_extractor.py
@@ -54,6 +54,7 @@ class AllwiseColorsFeatureExtractor(FeatureExtractor):
 
         features_df["sid"] = sid
         features_df["version"] = self.version
+        features_df["value"] = features_df["value"].astype(np.float64)
 
         all_features = [astro_object.features, features_df]
         astro_object.features = pd.concat(


### PR DESCRIPTION
## Summary of the changes

Nan values from WISE metadata were not being converted to None before they were not numpy.nan values. This PR solves that