### PR TITLE
Moved min detection criterion to execute in lc_classification_step

### DIFF
--- a/lc_classification_step/tests/integration/test_step_mbappe.py
+++ b/lc_classification_step/tests/integration/test_step_mbappe.py
@@ -90,14 +90,9 @@ def test_step_mbappe_no_features_result(
 
 
 @pytest.mark.ztf
-def test_step_mbappe_min_detections(
-    kafka_service,
-    produce_messages,
+def test_step_mbappe_min_detections_greater(
     env_variables_mbappe,
-    kafka_consumer: Callable[[str], KafkaConsumer],
-    scribe_consumer: Callable[[], KafkaConsumer],
 ):
-
     env_variables_mbappe(
         "mbappe",
         "alerce_classifiers.mbappe.model.MbappeClassifier",
@@ -106,23 +101,85 @@ def test_step_mbappe_min_detections(
             "QUANTILES_PATH": os.getenv("TEST_MBAPPE_QUANTILES_PATH"),
             "CONFIG_PATH": os.getenv("TEST_MBAPPE_CONFIG_PATH"),
             "MAPPER_CLASS": "alerce_classifiers.mbappe.mapper.MbappeMapper",
-            "MIN_DETECTIONS": "6",
+            "MIN_DETECTIONS": "2",
         },
     )
 
     from settings import config
+    from .conftest import INPUT_SCHEMA_PATH, add_fields_to_message
+    from fastavro.utils import generate_many
+    from fastavro.schema import load_schema
+    import random
 
-    produce_messages("features_mbappe", n_forced=6)
+    random.seed(42)
+    schema = load_schema(str(INPUT_SCHEMA_PATH))
+    messages = generate_many(schema, 2)  # 1 object has features
+    messages = list(messages)
+
+    for message in messages:
+        message = add_fields_to_message(
+            message,
+            "features_ztf",
+            ["g", "r"],
+            False,
+            False,
+            5,
+        )
+        for det in message["detections"]:
+            if not det["forced"]:
+                det["extra_fields"]["rb"] = 0.8
+
     step = LateClassifier(config=config())
-    step.execute = mock.MagicMock()
-    step.start()
-    step.execute.assert_not_called()
 
-    produce_messages("features_mbappe", n_forced=2)
-    kconsumer = kafka_consumer("mbappe")
+    output, result_messages, features = step.execute(messages)
+    probabilities = output.probabilities
+
+    assert len(probabilities) == 1
+
+
+@pytest.mark.ztf
+def test_step_mbappe_min_detections_lower(
+    env_variables_mbappe,
+):
+    env_variables_mbappe(
+        "mbappe",
+        "alerce_classifiers.mbappe.model.MbappeClassifier",
+        {
+            "MODEL_PATH": os.getenv("TEST_MBAPPE_MODEL_PATH"),
+            "QUANTILES_PATH": os.getenv("TEST_MBAPPE_QUANTILES_PATH"),
+            "CONFIG_PATH": os.getenv("TEST_MBAPPE_CONFIG_PATH"),
+            "MAPPER_CLASS": "alerce_classifiers.mbappe.mapper.MbappeMapper",
+            "MIN_DETECTIONS": "8",
+        },
+    )
+
+    from settings import config
+    from .conftest import INPUT_SCHEMA_PATH, add_fields_to_message
+    from fastavro.utils import generate_many
+    from fastavro.schema import load_schema
+    import random
+
+    random.seed(42)
+    schema = load_schema(str(INPUT_SCHEMA_PATH))
+    messages = generate_many(schema, 2)
+    messages = list(messages)
+
+    for message in messages:
+        message = add_fields_to_message(
+            message,
+            "features_ztf",
+            ["g", "r"],
+            False,
+            False,
+            5,
+        )
+        for det in message["detections"]:
+            if not det["forced"]:
+                det["extra_fields"]["rb"] = 0.8
+
     step = LateClassifier(config=config())
-    step.start()
 
-    for message in kconsumer.consume():
-        assert_ztf_object_is_correct(message)
-        kconsumer.commit()
+    output, result_messages, features = step.execute(messages)
+    probabilities = output.probabilities
+
+    assert len(probabilities) == 0

--- a/lc_classification_step/tests/integration/test_step_squidward.py
+++ b/lc_classification_step/tests/integration/test_step_squidward.py
@@ -86,52 +86,6 @@ def test_step_squidward_no_features_result(
 
 
 @pytest.mark.ztf
-def test_step_squidward_min_detections_greater(
-    env_variables_squidward,
-):
-    env_variables_squidward(
-        "squidward",
-        "alerce_classifiers.squidward.model.SquidwardFeaturesClassifier",
-        {
-            "MODEL_PATH": os.getenv("TEST_SQUIDWARD_MODEL_PATH"),
-            "MAPPER_CLASS": "alerce_classifiers.squidward.mapper.SquidwardMapper",
-            "MIN_DETECTIONS": "2",
-        },
-    )
-
-    from settings import config
-    from .conftest import INPUT_SCHEMA_PATH, add_fields_to_message
-    from fastavro.utils import generate_many
-    from fastavro.schema import load_schema
-    import random
-
-    random.seed(42)
-    schema = load_schema(str(INPUT_SCHEMA_PATH))
-    messages = generate_many(schema, 2)  # 1 object has features
-    messages = list(messages)
-
-    for message in messages:
-        message = add_fields_to_message(
-            message,
-            "features_ztf",
-            ["g", "r"],
-            False,
-            False,
-            5,
-        )
-        for det in message["detections"]:
-            if not det["forced"]:
-                det["extra_fields"]["rb"] = 0.8
-
-    step = LateClassifier(config=config())
-
-    output, result_messages, features = step.execute(messages)
-    probabilities = output.probabilities
-
-    assert len(probabilities) == 1
-
-
-@pytest.mark.ztf
 def test_step_squidward_min_detections_lower(
     env_variables_squidward,
 ):
@@ -159,15 +113,12 @@ def test_step_squidward_min_detections_lower(
     for message in messages:
         message = add_fields_to_message(
             message,
-            "features_ztf",
+            "features_squidward",
             ["g", "r"],
             False,
             False,
             5,
         )
-        for det in message["detections"]:
-            if not det["forced"]:
-                det["extra_fields"]["rb"] = 0.8
 
     step = LateClassifier(config=config())
 
@@ -175,3 +126,36 @@ def test_step_squidward_min_detections_lower(
     probabilities = output.probabilities
 
     assert len(probabilities) == 0
+
+    del step
+
+
+@pytest.mark.ztf
+def test_step_squidward_min_detections_greater(
+    kafka_service,
+    produce_messages,
+    env_variables_squidward,
+    kafka_consumer: Callable[[str], KafkaConsumer],
+    scribe_consumer: Callable[[], KafkaConsumer],
+):
+
+    env_variables_squidward(
+        "squidward",
+        "alerce_classifiers.squidward.model.SquidwardFeaturesClassifier",
+        {
+            "MODEL_PATH": os.getenv("TEST_SQUIDWARD_MODEL_PATH"),
+            "MAPPER_CLASS": "alerce_classifiers.squidward.mapper.SquidwardMapper",
+            "MIN_DETECTIONS": "6",
+        },
+    )
+
+    from settings import config
+
+    produce_messages("features_squidward", n_forced=2)
+    kconsumer = kafka_consumer("squidward")
+    step = LateClassifier(config=config())
+    step.start()
+
+    for message in kconsumer.consume():
+        assert_ztf_object_is_correct(message)
+        kconsumer.commit()

--- a/lc_classification_step/tests/integration/test_step_squidward.py
+++ b/lc_classification_step/tests/integration/test_step_squidward.py
@@ -86,37 +86,92 @@ def test_step_squidward_no_features_result(
 
 
 @pytest.mark.ztf
-def test_step_squidward_min_detections(
-    kafka_service,
-    produce_messages,
+def test_step_squidward_min_detections_greater(
     env_variables_squidward,
-    kafka_consumer: Callable[[str], KafkaConsumer],
-    scribe_consumer: Callable[[], KafkaConsumer],
 ):
-
     env_variables_squidward(
         "squidward",
         "alerce_classifiers.squidward.model.SquidwardFeaturesClassifier",
         {
             "MODEL_PATH": os.getenv("TEST_SQUIDWARD_MODEL_PATH"),
             "MAPPER_CLASS": "alerce_classifiers.squidward.mapper.SquidwardMapper",
-            "MIN_DETECTIONS": "6",
+            "MIN_DETECTIONS": "2",
         },
     )
 
     from settings import config
+    from .conftest import INPUT_SCHEMA_PATH, add_fields_to_message
+    from fastavro.utils import generate_many
+    from fastavro.schema import load_schema
+    import random
 
-    produce_messages("features_squidward", n_forced=6)
+    random.seed(42)
+    schema = load_schema(str(INPUT_SCHEMA_PATH))
+    messages = generate_many(schema, 2)  # 1 object has features
+    messages = list(messages)
+
+    for message in messages:
+        message = add_fields_to_message(
+            message,
+            "features_ztf",
+            ["g", "r"],
+            False,
+            False,
+            5,
+        )
+        for det in message["detections"]:
+            if not det["forced"]:
+                det["extra_fields"]["rb"] = 0.8
+
     step = LateClassifier(config=config())
-    step.execute = mock.MagicMock()
-    step.start()
-    step.execute.assert_not_called()
 
-    produce_messages("features_squidward", n_forced=2)
-    kconsumer = kafka_consumer("squidward")
+    output, result_messages, features = step.execute(messages)
+    probabilities = output.probabilities
+
+    assert len(probabilities) == 1
+
+
+@pytest.mark.ztf
+def test_step_squidward_min_detections_lower(
+    env_variables_squidward,
+):
+    env_variables_squidward(
+        "squidward",
+        "alerce_classifiers.squidward.model.SquidwardFeaturesClassifier",
+        {
+            "MODEL_PATH": os.getenv("TEST_SQUIDWARD_MODEL_PATH"),
+            "MAPPER_CLASS": "alerce_classifiers.squidward.mapper.SquidwardMapper",
+            "MIN_DETECTIONS": "8",
+        },
+    )
+
+    from settings import config
+    from .conftest import INPUT_SCHEMA_PATH, add_fields_to_message
+    from fastavro.utils import generate_many
+    from fastavro.schema import load_schema
+    import random
+
+    random.seed(42)
+    schema = load_schema(str(INPUT_SCHEMA_PATH))
+    messages = generate_many(schema, 2)
+    messages = list(messages)
+
+    for message in messages:
+        message = add_fields_to_message(
+            message,
+            "features_ztf",
+            ["g", "r"],
+            False,
+            False,
+            5,
+        )
+        for det in message["detections"]:
+            if not det["forced"]:
+                det["extra_fields"]["rb"] = 0.8
+
     step = LateClassifier(config=config())
-    step.start()
 
-    for message in kconsumer.consume():
-        assert_ztf_object_is_correct(message)
-        kconsumer.commit()
+    output, result_messages, features = step.execute(messages)
+    probabilities = output.probabilities
+
+    assert len(probabilities) == 0


### PR DESCRIPTION
## Summary of the changes

Application of min detection criterion is moved from pre_execute to execute to "process" all messages received. If kept in pre_execute, messages with less than minimum detections remain in the queue


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [X] Your changes were tested with manual testing before being submitted.
- [X] Your changes were tested with automatic unit tests.
- [X] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->