### PR TITLE
Fixed candid definition for forced photometry epochs from db

### DIFF
--- a/.github/workflows/lightcurve_step.yaml
+++ b/.github/workflows/lightcurve_step.yaml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/poetry-tests-template.yaml
     with:
       base-folder: "lightcurve-step"
-      python-version: "3.9"
+      python-version: "3.10"
       test-folder: "tests/unittest"
     secrets:
       GH_TOKEN: "${{ secrets.ADMIN_TOKEN }}"
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/poetry-tests-template.yaml
     with:
       base-folder: "lightcurve-step"
-      python-version: "3.9"
+      python-version: "3.10"
       test-folder: "tests/integration"
       codecov-flags: "" # Do not upload
     secrets:

--- a/lightcurve-step/lightcurve_step/parser_sql.py
+++ b/lightcurve-step/lightcurve_step/parser_sql.py
@@ -119,6 +119,7 @@ def parse_sql_forced_photometry(ztf_models: list, *, oids) -> list:
             for k, v in fp["extra_fields"].items()
             if not k.startswith("_")
         }
+
         # remove problematic fields
         FIELDS_TO_REMOVE = [
             "stellar",


### PR DESCRIPTION
## Summary of the changes

In the lightcurve step, the candid was not well defined for forced photometry epochs from the SQL DB, so they all had candid=None. After de-duplication, only 1 epoch survived. This PR assigns correctly a candid=oid+pid for them


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [X] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.