### PR TITLE
Fixed removal of columns when creating astro_object

### DIFF
--- a/feature_step/features/utils/parsers.py
+++ b/feature_step/features/utils/parsers.py
@@ -125,7 +125,9 @@ def detections_to_astro_object(
     a_flux["unit"] = "diff_flux"
     a = pd.concat([a, a_flux], axis=0)
     a.set_index("aid", inplace=True)
-    a.drop(columns=["mag", "e_mag"], inplace=True)  # NEW
+    for col in ["mag", "e_mag"]:
+        if col in a.columns:
+            a.drop(columns=[col], inplace=True)
 
     aid = a.index.values[0]
     oid = a["oid"].iloc[0]


### PR DESCRIPTION
## Summary of the changes

When creating the astro_object in feature_step, columns were dropped before checking the existence of the columns. This PR solves that


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [X] Your changes were tested with automatic unit tests.
- [X] Your changes were tested with automatic integration tests.