### PR TITLE
Removed redundant sorting

### DIFF
--- a/lc_classification_step/lc_classification/core/parsers/input_dto.py
+++ b/lc_classification_step/lc_classification/core/parsers/input_dto.py
@@ -60,15 +60,6 @@ def create_detections_dto(messages: List[dict]) -> pd.DataFrame:
     detections = detections.set_index("oid")
     detections["extra_fields"] = parse_extra_fields(detections)
 
-    if "mjd" in detections.columns:
-        column_sort = (
-            ["mjd", "forced"] if "forced" in detections.columns else "mjd"
-        )
-        order_sort = [True, False] if "forced" in detections.columns else True
-        detections.sort_values(
-            by=column_sort, ascending=order_sort, inplace=True
-        )
-
     if detections is not None:
         return detections
     else:


### PR DESCRIPTION
## Summary of the changes

Light curve sorting (in oid, mjd and forced flag) now is done only within the model mapper that uses the light curve (e.g. ATAT)

## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [X] Your changes were tested with automatic unit tests.
- [X] Your changes were tested with automatic integration tests.