### PR TITLE
Removed oids from messages after drop_bad_sn

### DIFF
--- a/stamp_classifier_2025_step/stamp_classifier_2025_step/parsers/stamp_parser.py
+++ b/stamp_classifier_2025_step/stamp_classifier_2025_step/parsers/stamp_parser.py
@@ -14,7 +14,7 @@ class StampParser(KafkaParser):
         self, model_output: OutputDTO, messages: dict, **kwargs
     ) -> KafkaOutput[list]:
 
-        parsed = {}
+        parsed = []
         probabilities = model_output.probabilities
         for oid, msg in messages.items():
             try:

--- a/stamp_classifier_2025_step/stamp_classifier_2025_step/parsers/stamp_parser.py
+++ b/stamp_classifier_2025_step/stamp_classifier_2025_step/parsers/stamp_parser.py
@@ -13,7 +13,6 @@ class StampParser(KafkaParser):
     def parse(
         self, model_output: OutputDTO, messages: dict, **kwargs
     ) -> KafkaOutput[list]:
-
         parsed = []
         probabilities = model_output.probabilities
         for oid, msg in messages.items():
@@ -37,4 +36,3 @@ class StampParser(KafkaParser):
         if oid not in probabilities.index:
             return {"error": "OID not found"}
         return probabilities.loc[oid].to_dict()
-

--- a/stamp_classifier_2025_step/stamp_classifier_2025_step/parsers/stamp_parser.py
+++ b/stamp_classifier_2025_step/stamp_classifier_2025_step/parsers/stamp_parser.py
@@ -14,7 +14,7 @@ class StampParser(KafkaParser):
         self, model_output: OutputDTO, messages: dict, **kwargs
     ) -> KafkaOutput[list]:
 
-        parsed = []
+        parsed = {}
         probabilities = model_output.probabilities
         for oid, msg in messages.items():
             try:

--- a/stamp_classifier_2025_step/stamp_classifier_2025_step/step.py
+++ b/stamp_classifier_2025_step/stamp_classifier_2025_step/step.py
@@ -189,7 +189,6 @@ class MultiScaleStampClassifier(GenericStep):
         return messages_filtered
 
     def _messages_to_input_dto(self, messages: List[dict]) -> InputDTO:
-
         ## get only necessary information form each msg
         records = []
         for msg in messages:
@@ -236,6 +235,18 @@ class MultiScaleStampClassifier(GenericStep):
             self.logger.info(f" output : {output_dto}")
             store_probability(
                 self.engine, self.classifier_name, self.classifier_version, output_dto
+            )
+
+            oids_removed = [
+                k
+                for k in messages_dict.keys()
+                if k not in output_dto.probabilities.index
+            ]
+            n_messages_total = len(messages_dict)
+            for oid in oids_removed:
+                messages_dict.pop(oid)
+            logging.info(
+                f"Kept {len(messages_dict)}/{n_messages_total} messages with valid probabilities."
             )
 
             return output_dto, messages_dict, DataFrame()


### PR DESCRIPTION
## Summary of the changes

Using drop_bad_sn can lead to a mismatch in the length of the probabilities dataframe and of the messages. This PR removes from the messages the oids that were removed from the probabilities dataframe (if any).