### PR TITLE
lc_classifier: Modified tqdm pbar import

### DIFF
--- a/lc_classifier/lc_classifier/features/core/base.py
+++ b/lc_classifier/lc_classifier/features/core/base.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 import pandas as pd
 
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 @dataclass


### PR DESCRIPTION
When lc_classifier is extracting features, the current implementation uses the default tqdm module intended for scripts, even if running on an IPy Notebook. tqdm does offer a notebook variant, but, it also offers the ability to infer it automatically through tqdm.auto.

I modified the code to import from ```tqdm.auto``` instead of ```tqdm```. This will automatically invoke the right type of progress bar to be used depending on the platform (script v/s notebook).

## Summary of the changes

Changed ```from tqdm import tqdm``` to ```from tqdm.auto import tqdm```


## Observations

This probably adds a very small overhead to the import as tqdm automatically infers the type of platform, namely, it tries in the following order:
- `tqdm.autonotebook` without import warnings
- `tqdm.asyncio`
- `tqdm.std` base class

But, this overhead should still be negligible, and will be helpful for people using it on IPy Notebooks (like me!)

Ref: https://github.com/tqdm/tqdm/blob/master/tqdm/auto.py