### PR TITLE
feat: add lsst models

### DIFF
--- a/libs/db-plugins-multisurvey/db_plugins/db/sql/models.py
+++ b/libs/db-plugins-multisurvey/db_plugins/db/sql/models.py
@@ -121,8 +121,30 @@ class ZtfDetection(Base):
     )
 
 
-class ForcedPhotometry(Base):
+class LsstDetection(Base):
+    __tablename__ = "lsst_detection"
 
+    oid = Column(BigInteger, nullable=False)  # int8,
+    measurement_id = Column(BigInteger, nullable=False)  # int8,
+    parentDiaSourceId = Column(BigInteger)
+
+    psfFlux = Column(REAL, nullable=False)
+    psfFluxErr = Column(REAL, nullable=False)
+
+    psfFlux_flag = Column(Boolean, nullable=False)
+    psfFlux_flag_edge = Column(Boolean, nullable=False)
+    psfFlux_flag_noGoodPixels = Column(Boolean, nullable=False)
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "oid", "measurement_id", name="pk_lsstdetection_oid_measurementid"
+        ),
+        ForeignKeyConstraint([oid], [Object.oid]),
+        Index("ix_lsstdetection_oid", "oid", postgresql_using="hash"),
+    )
+
+
+class ForcedPhotometry(Base):
     __tablename__ = "forced_photometry"
 
     oid = Column(BigInteger, nullable=False)  # int8,
@@ -191,6 +213,27 @@ class ZtfForcedPhotometry(Base):
     )
 
 
+class LsstForcedPhotometry(Base):
+    __tablename__ = "lsst_forced_photometry"
+
+    oid = Column(BigInteger, nullable=False)  # int8,
+    measurement_id = Column(BigInteger, nullable=False)  # int8,
+
+    visit = Column(BigInteger, nullable=False)
+    detector = Column(Integer, nullable=False)
+
+    psfFlux = Column(REAL, nullable=False)
+    psfFluxErr = Column(REAL, nullable=False)
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "oid", "measurement_id", name="pk_lsstforcedphotometry_oid_measurementid"
+        ),
+        ForeignKeyConstraint([oid], [Object.oid]),
+        Index("ix_lsst_forced_photometry_oid", "oid", postgresql_using="hash"),
+    )
+
+
 class NonDetection(Base):
     __tablename__ = "non_detection"
 
@@ -203,6 +246,22 @@ class NonDetection(Base):
         PrimaryKeyConstraint("oid", "mjd", name="pk_oid_mjd"),
         ForeignKeyConstraint([oid], [Object.oid]),
         Index("ix_non_detection_oid", "oid", postgresql_using="hash"),
+    )
+
+
+class LsstNonDetection(Base):
+    __tablename__ = "lsst_non_detection"
+
+    oid = Column(BigInteger, nullable=False)  # int8,
+    ccdVisitId = Column(BigInteger, nullable=False)
+    band = Column(SmallInteger, nullable=False)
+    mjd = Column(DOUBLE_PRECISION, nullable=False)
+    diaNoise = Column(REAL, nullable=False)
+
+    __table_args__ = (
+        PrimaryKeyConstraint("oid", "mjd", name="pk_lsstnondetection_oid_mjd"),
+        ForeignKeyConstraint([oid], [Object.oid]),
+        Index("ix_lsst_non_detection_oid", "oid", postgresql_using="hash"),
     )
 
 
@@ -344,6 +403,7 @@ class ztf_reference(Base):
         Index("ix_ztf_reference_oid", "oid", postgresql_using="btree"),
     )
 
+
 class MagStat(Base):
     __tablename__ = "magstat"
 
@@ -378,3 +438,4 @@ class MagStat(Base):
         PrimaryKeyConstraint("oid", "band", name="pk_magstat_oid_band"),
         ForeignKeyConstraint([oid], [Object.oid]),
     )
+


### PR DESCRIPTION
## Summary of the changes

Added new SQLAlchemy models for LSST survey data support in the multisurvey database plugin. The changes include:
- `LsstDetection` model for LSST detection data with PSF flux measurements and flags
- `LsstForcedPhotometry` model for LSST forced photometry data with visit and detector information  
- `LsstNonDetection` model for LSST non-detection data with CCD visit information
- Minor formatting fixes (added missing newline at end of file)

## Observations

- The new models follow the same pattern as existing ZTF models with appropriate primary keys, foreign key constraints, and indexes
- LSST models use similar field naming conventions but with LSST-specific fields like `visit`, `detector`, and `ccdVisitId`
- All new models include proper nullable constraints and data types consistent with the database schema

## If the change is BREAKING, please give more details about the breaking changes

This is not a breaking change. The changes are purely additive - adding new models for LSST survey support without modifying existing functionality.

#### Components that need updates and steps to follow

No additional components need updates as this only adds new models. The changes are contained within the database models layer.

## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.
