### PR TITLE
extractors first documentation

### DIFF
--- a/lc_classifier/lc_classifier/features/extractors/docs/NOTABLE_FINDINGS.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/NOTABLE_FINDINGS.md
@@ -1,0 +1,123 @@
+# Notable Findings Across Feature Extractors
+
+Cross-extractor summary of behaviours that are surprising, undocumented, or load-bearing in non-obvious ways. Compiled from the per-extractor reference docs in this directory. Read this before relying on any feature numerically — several values are not what their names suggest.
+
+Each entry links to the extractor's own doc for the full context.
+
+---
+
+## Process-global side effects
+
+These are mutations that affect the entire Python process, not just the extractor that owns them.
+
+- **`tde_extractor.py` and `ulens_extractor.py`** both call `jax.config.update("jax_enable_x64", True)` at **module import time**. Importing either extractor (e.g. via `from lc_classifier.features.extractors import ...`) silently promotes all JAX computations in the process to 64-bit for its remaining lifetime. Anything else in the process that assumed 32-bit JAX will run slower and may produce different numerics. See [tde_extractor.md](tde_extractor.md), [ulens_extractor.md](ulens_extractor.md).
+
+---
+
+## Silently wrong units, scales, or pivots
+
+Values whose physical interpretation is different from what their name suggests.
+
+- **`SPMExtractor` rescales flux by `× 0.001` before fitting** (legacy µJy → mJy conversion). `SPM_A` is therefore in a rescaled mJy-equivalent unit, not the pipeline's native µJy. Any downstream consumer treating `SPM_A` as a physical amplitude in µJy is wrong by 1000×. See [spm_extractor.md](spm_extractor.md).
+
+- **`SPMExtractor` cosmological correction pivots at `z = 0.3`, not `z = 0`**. Flux at the host redshift is normalised relative to `z = 0.3`, so `SPM_A` is *not* a redshift-corrected intrinsic luminosity proxy — it systematically depends on whether the object is above or below the pivot. See [spm_extractor.md](spm_extractor.md).
+
+- **`MicroLensExtractor` reduced χ² uses `N − 4` despite the model having 5 free parameters** (`u0`, `tE`, `fs`, `t0`, `mag_0`). `ulens_chi` is systematically lower than the textbook reduced χ² definition. Intent is undocumented. See [ulens_extractor.md](ulens_extractor.md).
+
+- **`PeriodExtractor` / `P4J.set_data` silently casts time arrays to `float32`**. At ZTF/LSST MJDs (~58000–70000) this gives only ~4 s of time resolution, degrading period accuracy near the `smallest_period = 0.045 d` lower bound. See [period_extractor.md](period_extractor.md).
+
+- **`CoordinateExtractor` averages RA directly in degrees**, which is wrong near the 0°/360° wrap. The source explicitly comments that the unit-vector-average fix is known and intentionally skipped for performance — any object whose detections straddle that boundary will silently produce incorrect Cartesian coordinates. See [coordinate_extractor.md](coordinate_extractor.md).
+
+---
+
+## Order- or context-dependent features
+
+Features that depend on other extractors having run first, or on the order of operations inside the extractor.
+
+- **`turbofats_extractor.py`**: the feature-name list is load-bearing. `SF_ML_gamma` reads `shared_data["g_sf"]` deposited by `SF_ML_amplitude` — reordering the list or removing `SF_ML_amplitude` raises an exception that is then **swallowed to `NaN`** with no loud signal. See [turbofats_extractor.md](turbofats_extractor.md).
+
+- **`FoldedKimExtractor` and `HarmonicsExtractor` both require a preceding `PeriodExtractor`** to have written `Multiband_period` into `astro_object.features`. There is no soft-fail path: a missing period raises an uncaught exception. See [folded_kim_extractor.md](folded_kim_extractor.md), [harmonics_extractor.md](harmonics_extractor.md).
+
+- **`FoldedKimExtractor` folds over a `2 × period` window**, not one full cycle. This is a silent deviation from the turbofats `Psi_CS_v2`/`Psi_eta_v2` definitions and from Kim et al. — values are not numerically comparable to the turbofats equivalents with the same name. See [folded_kim_extractor.md](folded_kim_extractor.md).
+
+- **`SNExtractor` derives `first_detection_mjd` across all bands combined, not per-band**. A band with an earlier first detection than other bands ends up with zero "before" epochs and 5/10 of its features become `NaN`, even when substantial pre-detection baseline data exist in that band. See [sn_extractor.md](sn_extractor.md).
+
+- **`AllwiseColorsFeatureExtractor`**: the consecutive AllWISE colors (`W1-W2`, `W2-W3`, `W3-W4`) are gated on the optical detection count after preprocessing. They are forced to `NaN` whenever no optical detections survive the filter, even when all four AllWISE magnitudes are present in metadata — an undocumented coupling between the IR-only colors and the optical path. See [allwise_colors_feature_extractor.md](allwise_colors_feature_extractor.md).
+
+- **`HarmonicsExtractor` reads the period via `period["value"][0]` (label-based)** rather than `.iloc[0]`. After a DataFrame concat where the integer label `0` is absent or duplicated, this silently returns the wrong value or raises a `KeyError`. See [harmonics_extractor.md](harmonics_extractor.md).
+
+---
+
+## Silent failure modes
+
+Errors that should be loud but become `NaN`, default values, or success-looking output.
+
+- **`GPDRWExtractor` never checks `sol.success`** after `scipy.optimize.minimize`. Non-converged fits emit numeric `GP_DRW_sigma` / `GP_DRW_tau` values indistinguishable from converged ones in the feature table. See [gp_drw_extractor.md](gp_drw_extractor.md).
+
+- **`MHPSExtractor` silently drops `non_zero` and `pn_flag` outputs** when `t1 != 100.0` or `t2 != 10.0`, despite the library still computing them. Pure information loss with no warning. See [mhps_extractor.md](mhps_extractor.md).
+
+- **`MHPSExtractor`'s `self.dt = 3.0` is stored but never passed to `mhps.statistics` / `mhps.flux_statistics`**. The library applies its own internal default for the convolution time step. The constructor argument is misleading. See [mhps_extractor.md](mhps_extractor.md).
+
+- **`turbofats.IAR_phi` emits `1e10` (not `NaN`) when `|phi| >= 1`** internally, before the outer exception catcher converts the bad value to `NaN`. Inspecting raw turbofats output directly (outside the extractor wrapper) will show sentinel values, not NaNs. See [turbofats_extractor.md](turbofats_extractor.md).
+
+- **`TimespanExtractor` has no guard against an empty `detections` DataFrame**. Pandas silently returns `NaN` for `min`/`max`; `Timespan` becomes `NaN` with no sentinel path. See [timespan_extractor.md](timespan_extractor.md).
+
+---
+
+## Hardcoded thresholds and sentinels
+
+Magic numbers that materially shape feature values and are not exposed as constructor arguments.
+
+- **`e_brightness < 1.0` magnitude-error cap** — hardcoded in `preprocess_detections` and reused across multiple extractors (`AllwiseColorsFeatureExtractor`, `ColorFeatureExtractor`, etc.). No override. Sparse-band detections with reasonable but loose uncertainty (e.g. 1.2 mag) are silently dropped. See [allwise_colors_feature_extractor.md](allwise_colors_feature_extractor.md), [color_feature_extractor.md](color_feature_extractor.md).
+
+- **`ColorFeatureExtractor` flux-ratio denominator adds `+ 1` µJy** (`band_p90_list[i+1] + 1`). For faint objects with p90 fluxes in the single-digit µJy range, this hardcoded additive bias compresses color ratios toward 1. Not tunable. See [color_feature_extractor.md](color_feature_extractor.md).
+
+- **`ColorFeatureExtractor` differential-flux path has no error quality filter at all** (unlike the magnitude path which uses the 1.0 mag cap). `_mean` / `_max` features without the `_corr` suffix can include arbitrarily low-SNR detections. See [color_feature_extractor.md](color_feature_extractor.md).
+
+- **`PanStarrsFeatureExtractor` non-detection sentinel is hardcoded at `< -30.0` mag** (PanSTARRS/ZTF convention). Catalogues that flag non-detections with `NaN` or `99.0` will silently produce finite colors. See [panstarrs_feature_extractor.md](panstarrs_feature_extractor.md).
+
+- **`ReferenceFeatureExtractor` clips `distnr` at 5 arcsec**, justified in a source comment as a ZTF training-set limitation. Detections beyond that radius are silently discarded. See [reference_feature_extractor.md](reference_feature_extractor.md).
+
+- **`HarmonicsExtractor` uses two asymmetric error floors**: an unconditional `10⁻²` added to `e_brightness` for the fit weights, and a separate `error_tol` (`1e-2` for mags, `1e-3` for `diff_flux`) added only to the χ² denominator. For `unit="diff_flux"` the fit is regularised with a floor 10× larger than the χ² floor. See [harmonics_extractor.md](harmonics_extractor.md).
+
+- **`PeriodExtractor` PPE has a `1e-2` additive floor in its entropy**, so PPE is never exactly 0 or 1, and a uniform top-100 periodogram can produce a slightly negative PPE. The feature's range is not a clean `[0, 1]` probability. See [period_extractor.md](period_extractor.md).
+
+- **`turbofats.Meanvariance` (`std / mean`) has no guard against near-zero mean**, which is a real failure mode for `unit="diff_flux"` (used in the ELAsTiCC composite) on faint sources centred near zero flux. See [turbofats_extractor.md](turbofats_extractor.md).
+
+- **`TDETailExtractor` calls `np.abs(brightness)` before converting to magnitude**, so negative-flux difference epochs (host-galaxy subtraction residuals, pre-peak baselines) are treated as same-magnitude positive detections. A large-absolute-value negative epoch can misplace `t_d` (the peak epoch). See [tde_extractor.md](tde_extractor.md).
+
+---
+
+## Dead code / misleading scaffolding
+
+Code that looks load-bearing but isn't, or imports/state that suggests behaviour the extractor doesn't have.
+
+- **`DummyExtractor` never sets `self.version`**. Any caller that reads `extractor.version` (production extractors all do, when stamping the `version` column in `astro_object.features`) will hit `AttributeError`. `lsst.py` imports `DummyExtractor` at module level but never instantiates it — dead import in production code. See [dummy_extractor.md](dummy_extractor.md).
+
+- **`PanStarrsFeatureExtractor` imports `functools.lru_cache` but never uses it** — suggests a copy-paste artifact from another extractor. See [panstarrs_feature_extractor.md](panstarrs_feature_extractor.md).
+
+- **`GPDRWExtractor` instantiates `celerite2.RealTerm(a=1.0, c=10.0)` once per band**, but those values are overwritten on the first `neg_log_like` call — constructor values have zero effect. (Note: celerite2 itself warns that `RealTerm` "will generally behave poorly" and recommends `SHOTerm` for most users — the choice here is a deliberate strict-DRW model decision.) See [gp_drw_extractor.md](gp_drw_extractor.md).
+
+- **`SNExtractor`'s `forced_photometry = forced_photometry[forced_photometry["unit"] == self.unit]`** sits inside the band loop and re-applies the same filter on every iteration — harmless but redundant after the first pass. See [sn_extractor.md](sn_extractor.md).
+
+---
+
+## Unguarded type / data assumptions
+
+Latent crashes that depend on input shape rather than physical content.
+
+- **`ReferenceFeatureExtractor`'s `rfid`-to-`int` cast (line 62)** has no exception guard. Non-integer float values raise `ValueError` and propagate uncaught, while every other NaN/empty edge case in the extractor emits `np.nan` gracefully — an asymmetric failure mode. See [reference_feature_extractor.md](reference_feature_extractor.md).
+
+- **`CoordinateExtractor` has no NaN guard or minimum-detection count**. A single all-NaN `ra`/`dec` column propagates `NaN` through to features with no deliberate sentinel-emission path. See [coordinate_extractor.md](coordinate_extractor.md).
+
+- **`HarmonicsExtractor` `period["value"][0]` is a label-based lookup, not positional**. Works on a fresh DataFrame; breaks silently or loudly after a concat. See [harmonics_extractor.md](harmonics_extractor.md).
+
+---
+
+## Schema / structural surprises
+
+Output shapes that diverge from per-band conventions used elsewhere.
+
+- **`TimespanExtractor` emits its row with `fid = None` and `sid` as a comma-joined sorted *string*** (e.g. `"LSST,ZTF"`), not the usual bare identifier or list. Consumers iterating `astro_object.features` and assuming `sid` is a single survey identifier will mis-handle this row. See [timespan_extractor.md](timespan_extractor.md).
+
+- **`TurboFatsExtractor` suffixes every feature name with `_flux` when `unit="diff_flux"`** but emits the same name otherwise — a single feature column can mean different things across runs depending on the configured unit. See [turbofats_extractor.md](turbofats_extractor.md).

--- a/lc_classifier/lc_classifier/features/extractors/docs/allwise_colors_feature_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/allwise_colors_feature_extractor.md
@@ -1,0 +1,128 @@
+# AllwiseColorsFeatureExtractor
+
+Computes magnitude color indices between consecutive AllWISE infrared bands and between each optical survey band and each AllWISE band.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/allwise_colors_feature_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `numpy`, `pandas` (stdlib-level; no third-party scientific library)
+
+## Purpose / Meaning
+
+AllWISE infrared colors (W1−W2, W2−W3, W3−W4) and cross-survey colors (optical band − AllWISE band) encode information about the spectral energy distribution of a source. These color indices help distinguish stellar types and extragalactic objects (e.g. AGN, quasars) from transients, which typically have flat or blue infrared SEDs, making them useful discriminators in multi-class light-curve classifiers.
+
+## Input
+
+### Constructor arguments
+
+| Name    | Type        | Default | Meaning |
+|---------|-------------|---------|---------|
+| `bands` | `List[str]` | —       | Ordered list of optical band identifiers (e.g. `["g", "r"]` for ZTF, `["u","g","r","i","z","y"]` for LSST). Determines which cross-color features are produced. No default; required. |
+
+`self.allwise_bands` is hardcoded to `["W1", "W2", "W3", "W4"]` and is not a constructor argument.
+
+### `AstroObject` fields read
+
+- `detections` — columns used: `fid`, `brightness`, `e_brightness`, `unit`, `sid`. The mean brightness per band is computed from filtered detections.
+- `metadata` — a two-column DataFrame with `name` and `value` columns. The extractor looks up rows where `name` is `"W1"`, `"W2"`, `"W3"`, `"W4"` and reads the corresponding `value` as the AllWISE magnitude for that band. If a band is absent from `metadata`, `np.nan` is used.
+- `features` — read and extended in-place via `pd.concat`.
+
+`forced_photometry`, `non_detections`, `xmatch`, and `reference` are not read.
+
+### Pre-filtering applied
+
+The `preprocess_detections` method applies these filters to `detections` before any computation:
+
+1. Keep only rows where `unit == "magnitude"` — diff-flux detections are excluded entirely.
+2. Drop rows where `brightness` is `NaN`.
+3. Drop rows where `e_brightness >= 1.0` — a hardcoded uncertainty ceiling.
+
+The filtered DataFrame may be empty after these steps.
+
+### Valid `unit` values
+
+Only `"magnitude"` passes the filter. Any other unit (e.g. `"diff_flux"`) causes all optical band means to be `np.nan` because no detection survives.
+
+## Output
+
+Every row appended to `astro_object.features` has columns `name`, `value`, `fid`, `sid`, `version`. All rows from this extractor have `fid = None`.
+
+Feature names are produced by `_feature_names()` (cached with `@lru_cache(1)`):
+
+**AllWISE consecutive-band colors** (3 features, independent of `bands`):
+
+| Feature `name` | `fid` | Meaning |
+|----------------|-------|---------|
+| `W1-W2`        | `None` | AllWISE W1 magnitude minus AllWISE W2 magnitude |
+| `W2-W3`        | `None` | AllWISE W2 magnitude minus AllWISE W3 magnitude |
+| `W3-W4`        | `None` | AllWISE W3 magnitude minus AllWISE W4 magnitude |
+
+**Cross-survey optical-minus-AllWISE colors** (`len(bands) × 4` features):
+
+| Feature `name`    | `fid` | Meaning |
+|-------------------|-------|---------|
+| `<band>-W1`       | `None` | Mean optical `brightness` in `<band>` minus AllWISE W1 magnitude |
+| `<band>-W2`       | `None` | Mean optical `brightness` in `<band>` minus AllWISE W2 magnitude |
+| `<band>-W3`       | `None` | Mean optical `brightness` in `<band>` minus AllWISE W3 magnitude |
+| `<band>-W4`       | `None` | Mean optical `brightness` in `<band>` minus AllWISE W4 magnitude |
+
+For ZTF (`bands=["g","r"]`) this yields 8 cross-colors: `g-W1`, `g-W2`, `g-W3`, `g-W4`, `r-W1`, `r-W2`, `r-W3`, `r-W4`.  
+For LSST (`bands=["u","g","r","i","z","y"]`) this yields 24 cross-colors.
+
+**Total features:** 3 + `len(bands) × 4`.
+
+**`sid` field:** a comma-joined sorted string of all unique survey IDs present in the filtered detections (e.g. `"ZTF"` or `"LSST,ZTF"`). All feature rows for this extractor share the same `sid` value.
+
+**Sentinel value:** `np.nan` is emitted under the following conditions:
+- An AllWISE band is absent from `astro_object.metadata`: that band's value is `np.nan`, propagating to all colors that involve it.
+- An optical band has no detections surviving `preprocess_detections`: that band's mean is `np.nan`, propagating to all `<band>-W*` colors for that band.
+- An AllWISE consecutive-band delta (`W1-W2`, etc.) is `np.nan` when `len(detections) == 0` after preprocessing, regardless of whether AllWISE metadata is available (see *Important considerations*).
+
+## Underlying library / math
+
+No third-party scientific library is invoked. All computation uses:
+
+- `np.mean` — arithmetic mean of filtered `brightness` values per band.
+- `np.stack` / `pd.DataFrame` / `pd.concat` — feature assembly.
+- `np.sort` / `str.join` — `sid` string construction.
+
+The color is always computed as `a - b` where `a` and `b` are magnitudes (smaller magnitude = brighter). A positive color value means the source is brighter at the shorter wavelength.
+
+## Hardcoded values
+
+| Location | Value | Tunable? | Effect |
+|----------|-------|----------|--------|
+| `self.allwise_bands` | `["W1", "W2", "W3", "W4"]` | No | Determines which metadata rows are looked up and the set of infrared bands for color computation. |
+| `preprocess_detections` | `unit == "magnitude"` | No | Excludes all non-magnitude detections before computing optical means. |
+| `preprocess_detections` | `e_brightness < 1.0` | No | Rejects detections with uncertainty ≥ 1 magnitude. |
+| `_feature_names` | `@lru_cache(1)` | N/A | Feature name list is computed once per instance and cached. Safe only if `self.bands` and `self.allwise_bands` are never mutated after construction. |
+
+## Important considerations
+
+- **AllWISE delta guard is asymmetric.** The three consecutive AllWISE colors (`W1-W2`, `W2-W3`, `W3-W4`) are set to `np.nan` when `len(detections) == 0` (line `if len(detections) > 0`), but the cross-survey colors (`<band>-W*`) are computed unconditionally — they will be `np.nan` only if the optical band mean or an AllWISE value is `np.nan`. This means that if detections is empty, the AllWISE-only colors are forced to `np.nan` even when all four AllWISE magnitudes are available in metadata. This appears to be an unintended coupling: the AllWISE-only color should not logically depend on whether any optical detections exist.
+
+- **In-place mutation.** `compute_features_single_object` modifies `astro_object.features` in-place by replacing it with a `pd.concat` result. It does not reset the index, so the features DataFrame may have a non-contiguous index after multiple extractors run.
+
+- **`fid` is always `None`.** All features are emitted with `fid=None`, meaning they are not band-specific. Downstream consumers must not filter by `fid` when reading these features.
+
+- **`metadata` structure assumed.** The extractor assumes `astro_object.metadata` is a DataFrame with columns `"name"` and `"value"`. If `metadata` does not contain any W-band rows (e.g. when xmatch data is unavailable), all AllWISE values will be `np.nan` and all 3 + `len(bands)×4` features will be `np.nan`.
+
+- **How AllWISE magnitudes reach `metadata`.** In `lc_classifier/lc_classifier/utils.py` (~line 342), when an xmatch record is present, `W1`, `W2`, `W3`, `W4` are inserted as `["name", "value"]` rows into the metadata DataFrame. If xmatch is `None`, no W-band rows are added and every AllWISE feature will be `np.nan`.
+
+- **`value` dtype.** The `value` column is cast to `np.float64` after constructing the DataFrame from a mixed `np.stack` of name strings and float values. If a value cannot be cast (e.g. an unexpected string in metadata), a `ValueError` will propagate uncaught.
+
+- **No `min_length` guard.** Unlike most other extractors, there is no minimum number of detections required. A single surviving detection in a band is sufficient to compute a mean (equal to that detection's brightness).
+
+- **`_feature_names` cache is instance-level.** `@lru_cache(1)` on a method uses `self` as part of the cache key, so each instance has its own cached list. This is correct behavior but means the names are fixed at first call time.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `lc_classifier/lc_classifier/features/composites/ztf.py` — `ZTFFeatureExtractor`, instantiated as `AllwiseColorsFeatureExtractor(["g", "r"])`.
+  - `lc_classifier/lc_classifier/features/composites/lsst.py` — `LSSTFeatureExtractor`, instantiated as `AllwiseColorsFeatureExtractor(["u","g","r","i","z","y"])`.
+
+- **Other extractors that read the same `AstroObject` fields:**
+  - `detections` with `unit == "magnitude"` is also consumed by `ColorFeatureExtractor`, `FoldedKimExtractor`, `HarmonicsExtractor`, and `TurboFatsExtractor`.
+  - `metadata` W-band rows are populated by the xmatch utility in `lc_classifier/lc_classifier/utils.py`.
+
+- **Consumers of the emitted feature names:** No other extractor in the repo reads `W1-W2`, `W2-W3`, `W3-W4`, or `<band>-W*` feature names. These are terminal outputs consumed by downstream classifiers (models), not by other feature extractors.

--- a/lc_classifier/lc_classifier/features/extractors/docs/color_feature_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/color_feature_extractor.md
@@ -1,0 +1,139 @@
+# ColorFeatureExtractor
+
+Computes inter-band color indices from light-curve photometry, operating in either flux or magnitude mode depending on the `just_flux` constructor flag.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/color_feature_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `lc_classifier.utils` (`flux2mag`, `flux_err_2_mag_err`), `numpy`
+
+## Purpose / Meaning
+
+Color is the difference in brightness between two photometric bands measured simultaneously (or quasi-simultaneously) on the same object. It serves as a proxy for spectral shape and is one of the cheapest discriminators among transient and variable-star classes. This extractor produces one color per adjacent band pair (e.g. `g-r`, `r-i`) from the available detections, using either corrected magnitudes and differential magnitudes (when `just_flux=False`) or differential fluxes (when `just_flux=True`).
+
+## Input
+
+### Constructor arguments
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — (required) | Ordered list of band identifiers, e.g. `["g", "r"]` or `["u", "g", "r", "i", "z", "Y"]`. Colors are computed for each adjacent pair `bands[i]` vs `bands[i+1]`. |
+| `just_flux` | `bool` | — (required) | If `True`, operate purely on `diff_flux` rows and emit flux-ratio features. If `False`, operate on both `magnitude` and `diff_flux` rows and emit magnitude-difference features. |
+
+### `AstroObject` fields read
+
+- `detections` — all rows in `astro_object.detections`; columns used: `brightness`, `e_brightness`, `unit`, `fid`, `sid`.
+- `features` — read only to concatenate the new rows onto the existing `features` DataFrame.
+
+`forced_photometry` is **not** read by this extractor.
+
+### Pre-filtering applied
+
+**When `just_flux=True`** (`preprocess_detections_just_flux`):
+- Drop rows where `brightness` is `NaN`.
+- Keep only rows where `unit == "diff_flux"`.
+
+**When `just_flux=False`** (`preprocess_detections_just_magnitude`):
+- Drop rows where `brightness` is `NaN`.
+- Split into two sub-DataFrames:
+  - `corrected_mags`: rows where `unit == "magnitude"` **and** `e_brightness < 1.0`.
+  - `diff_magnitudes`: rows where `unit == "diff_flux"`, converted in-place to magnitudes (see *Underlying library / math* below); the converted rows are labeled `unit = "diff_magnitude"` after transformation.
+
+No minimum-length cutoff is enforced. A band with zero surviving detections produces `np.nan` for that band's statistic.
+
+### Valid `unit` values
+
+- `"magnitude"` — used as-is for the `corrected_mags` path (only when `just_flux=False`).
+- `"diff_flux"` — used as-is for the `just_flux=True` path; converted to magnitudes for the `diff_magnitudes` path.
+
+## Output
+
+Every row appended to `astro_object.features` has columns `name`, `value`, `fid`, `sid`, `version`.
+
+- `fid` is set to `",".join(self.bands)` for **all** features from this extractor (e.g. `"g,r"` for ZTF, `"u,g,r,i,z,Y"` for ELAsTiCC).
+- `sid` is set to `",".join(sorted(detections["sid"].unique()))`.
+- `version` is `"1.0.0"`.
+
+### Features when `just_flux=True`
+
+For each adjacent band pair `(bands[i], bands[i+1])`:
+
+| Feature `name` | `fid` scope | Meaning |
+|---|---|---|
+| `{bands[i]}-{bands[i+1]}` | all bands joined | 90th-percentile absolute flux of band `i` divided by (90th-percentile absolute flux of band `i+1` + 1). |
+
+The `+ 1` term in the denominator prevents division-by-zero when the next band has zero or very small flux. The denominator bias is hardcoded (see *Hardcoded values*).
+
+### Features when `just_flux=False`
+
+For each adjacent band pair `(bands[i], bands[i+1])`, four features are emitted — two from the `diff_magnitudes` path and two from the `corrected_mags` path:
+
+| Feature `name` | `fid` scope | Meaning |
+|---|---|---|
+| `{bands[i]}-{bands[i+1]}_mean` | all bands joined | Mean magnitude of band `i` minus mean magnitude of band `i+1`, computed on the `diff_magnitude` sub-set. |
+| `{bands[i]}-{bands[i+1]}_max` | all bands joined | Minimum magnitude (= maximum brightness) of band `i` minus minimum magnitude of band `i+1`, computed on the `diff_magnitude` sub-set. |
+| `{bands[i]}-{bands[i+1]}_mean_corr` | all bands joined | Same as `_mean` but computed on the `corrected_mags` sub-set. |
+| `{bands[i]}-{bands[i+1]}_max_corr` | all bands joined | Same as `_max` but computed on the `corrected_mags` sub-set. |
+
+**Sentinel:** if any band in a pair has zero detections after filtering, the corresponding statistic (mean or max) is `np.nan`, which propagates into the feature value as `np.nan` via normal arithmetic. No explicit `np.nan` guard is added; the arithmetic (`np.nan - float` or `float - np.nan`) produces `np.nan` naturally.
+
+No short-circuit path exists; the extractor always appends rows even when all values are `np.nan`.
+
+## Underlying library / math
+
+### `flux2mag` — `lc_classifier.utils`
+
+```python
+def flux2mag(flux):
+    """flux in uJy to AB magnitude"""
+    return -2.5 * np.log10(flux) + 23.9
+```
+
+Applied to the absolute value of `diff_flux` brightness (`np.abs(diff_fluxes["brightness"])`) before computing magnitude statistics. The zero-point `23.9` corresponds to the standard AB system calibrated to microjansky (`m_AB = -2.5 log10(f_uJy) + 23.9`). This value is hardcoded in `utils.py`.
+
+### `flux_err_2_mag_err` — `lc_classifier.utils`
+
+```python
+def flux_err_2_mag_err(flux_err, flux):
+    return (2.5 * flux_err) / (np.log(10.0) * flux)
+```
+
+Standard Gaussian error propagation for the logarithmic magnitude conversion. Applied to `e_brightness` before the magnitude conversion. Note: this is evaluated on the **absolute-valued** flux (`np.abs(diff_fluxes["brightness"])`) only for the magnitude conversion, but the `flux` argument passed inside `preprocess_detections_just_magnitude` is the already-abs-valued array (after `diff_fluxes["brightness"] = np.abs(...)`), so the propagation is consistent.
+
+### `numpy.percentile` (90th percentile, flux path)
+
+`np.percentile(band_flux_abs, 90)` — the 90th percentile of the absolute flux per band. No interpolation method is specified, so NumPy's default (`linear`) is used.
+
+### `numpy.mean` / `numpy.min` (magnitude path)
+
+- `np.mean(band_detections["brightness"])` — arithmetic mean of magnitude values.
+- `np.min(band_detections["brightness"])` — minimum value in the magnitude column, which corresponds to the **maximum brightness** (since lower magnitude = brighter). The code comment confirms this interpretation: `# max brightness, min magnitude`.
+
+## Hardcoded values
+
+| Value | Location | Tunable? | Effect |
+|---|---|---|---|
+| `90` (percentile) | `_diff_flux_colors`, `np.percentile(..., 90)` | Baked in | Controls the flux-color statistic; p90 of absolute flux per band. |
+| `1` (denominator bias) | `_diff_flux_colors`, `band_p90_list[i+1] + 1` | Baked in | Prevents division-by-zero in the flux-ratio color; adds 1 uJy to the denominator regardless of the actual flux scale. This is a numerical guard, not a physically motivated additive constant. |
+| `1.0` (error threshold) | `preprocess_detections_just_magnitude`, `e_brightness < 1.0` | Baked in | Rejects detections with photometric uncertainty >= 1 magnitude from the `corrected_mags` path. No equivalent cutoff on the `diff_flux` path. |
+| `"diff_magnitude"` (unit label) | `preprocess_detections_just_magnitude` | N/A | Internal label assigned after flux-to-magnitude conversion; not propagated to the features table. |
+
+## Important considerations
+
+- **`just_flux=True` vs `just_flux=False` produce incompatible feature schemas.** `just_flux=True` emits N−1 features (one flux ratio per adjacent pair); `just_flux=False` emits 4(N−1) features (mean/max × diff/corr). Downstream models must be trained with the same flag.
+- **`fid` column is multi-band joined string, not a single band identifier.** All features from this extractor share the same composite `fid` value (e.g. `"g,r"`). Consumers that filter by a single band `fid` will not find these rows.
+- **No forced photometry.** Unlike several other extractors in the same composite, `ColorFeatureExtractor` reads only `astro_object.detections`, ignoring `forced_photometry`.
+- **Absolute value taken before log in the flux path.** `diff_flux` can be negative (negative difference-image flux). The extractor takes `np.abs` before the 90th-percentile and before `flux2mag`. This means physically negative flux events (source fainter than reference) contribute positively to the color statistic and are converted to a positive magnitude-like quantity.
+- **`e_brightness < 1.0` filter applies only to `corrected_mags`.** Differential-flux detections converted to `diff_magnitude` are not subject to any error cut. If forced photometry data with poor uncertainties were merged into `detections` upstream, they would pass through the diff-magnitude path unchecked.
+- **Empty band produces `np.nan` via propagation, not an explicit sentinel.** `np.nan` is appended to `band_means`/`band_maxima`/`band_p90_list` when a band has no detections; subsequent arithmetic (`np.nan - x` or `x / (np.nan + 1)`) propagates `np.nan` naturally into the feature value. No exception is raised and the row is always written.
+- **In-place modification of intermediate DataFrame.** Inside `preprocess_detections_just_magnitude`, `diff_fluxes` is a `.copy()` of the filtered detections, so the original `astro_object.detections` is not mutated. The `just_flux` path does not copy; however, the filtered result is not written back to `astro_object`, so the original is also safe.
+- **`astro_object.features` is mutated in place** via `pd.concat` + reassignment at the end of `compute_features_single_object`.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `ZTFFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/ztf.py`) — `bands=["g","r"]`, `just_flux=False`.
+  - `LSSTFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/lsst.py`) — `bands=["u","g","r","i","z","y"]`, `just_flux=False`.
+  - `ElasticcFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/elasticc.py`) — `bands=["u","g","r","i","z","Y"]`, `just_flux=True`.
+- **Other extractors reading the same `detections` fields:** `TurboFatsExtractor`, `MHPSExtractor`, `HarmonicsExtractor`, `PeriodExtractor`, `TDETailExtractor`, and others — all read `brightness`, `e_brightness`, `fid`, `unit` from `astro_object.detections`.
+- **Consumers of emitted feature names:** No other extractor in the repo reads the feature names emitted here (e.g. `g-r_mean`, `g-r_max_corr`). These names are consumed by downstream classifier models (not in this repo) that ingest the full `astro_object.features` table.

--- a/lc_classifier/lc_classifier/features/extractors/docs/coordinate_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/coordinate_extractor.md
@@ -1,0 +1,129 @@
+# CoordinateExtractor
+
+Converts a sky object's mean equatorial coordinates (RA/Dec) into unit-sphere
+Cartesian coordinates and appends them as three scalar features.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/coordinate_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `numpy`, `pandas` (standard; no domain-specific scientific library)
+
+## Purpose / Meaning
+
+Positional features on the unit sphere (`x`, `y`, `z`) give a machine-learning
+model a smooth, continuous representation of sky position that avoids the
+discontinuity at RA = 0°/360° and the coordinate singularity at the poles.
+They are directly usable as regressor inputs without further trigonometric
+preprocessing.
+
+## Input
+
+### Constructor arguments
+
+None. `CoordinateExtractor` has no constructor and therefore no tunable
+parameters.
+
+### `AstroObject` fields read
+
+- `detections` — columns `ra` and `dec` (decimal degrees, equatorial J2000
+  assumed). The mean across all rows is taken.
+- `detections` — column `sid` (survey identifier string), used only to build
+  the `sid` label for the output rows.
+
+### Pre-filtering applied
+
+None. Every row in `detections` contributes equally to the arithmetic mean of
+`ra` and `dec`. No NaN-dropping, band filtering, or minimum-length guard is
+applied before the mean.
+
+### Valid `unit` values
+
+Not applicable. `CoordinateExtractor` does not read the `unit` column and
+performs no photometric computation.
+
+## Output
+
+Three rows appended to `astro_object.features` (columns `name`, `value`, `fid`,
+`sid`, `version`).
+
+| Feature `name`  | `fid` scope | Meaning |
+|-----------------|-------------|---------|
+| `Coordinate_x`  | `None` (all-band) | `cos(ra) * cos(dec)` on the unit sphere |
+| `Coordinate_y`  | `None` (all-band) | `sin(ra) * cos(dec)` on the unit sphere |
+| `Coordinate_z`  | `None` (all-band) | `sin(dec)` on the unit sphere |
+
+- All three values are dimensionless and lie in `[-1, 1]`.
+- `fid` is set to `None` for every row (position is not band-specific).
+- `sid` is set to a comma-separated, sorted string of all unique `sid` values
+  found in `detections` (e.g. `"ZTF"` or `"LSST,ZTF"`).
+- No sentinel value path exists: the extractor will raise a `KeyError` or
+  propagate a `NaN` from `pandas.DataFrame.mean` if `ra`/`dec` are missing or
+  entirely NaN — it does not guard against these cases.
+
+## Underlying library / math
+
+No domain-specific scientific library is called. The only numerical operations
+are:
+
+1. `detections[["ra","dec"]].mean()` — arithmetic mean across all detections.
+2. Degree-to-radian conversion: `ra_rad = ra_deg / 180.0 * np.pi`.
+3. Standard spherical-to-Cartesian projection (right-handed, ISO physics
+   convention with polar axis along z):
+
+   ```
+   x = cos(ra_rad) * cos(dec_rad)
+   y = sin(ra_rad) * cos(dec_rad)
+   z = sin(dec_rad)
+   ```
+
+   This uses the astronomical convention where Dec (not colatitude) is measured
+   from the equatorial plane, so `z = sin(dec)` rather than `cos(theta)`.
+
+No library defaults are inherited that affect numerical output.
+
+## Hardcoded values
+
+| Literal | Location | Tunable? | Effect |
+|---------|----------|----------|--------|
+| `180.0` | degree-to-radian conversion | no | exact; no approximation |
+| `np.pi` | degree-to-radian conversion | no | numpy's `float64` pi |
+
+No magic thresholds, band lists, or minimum-sample guards.
+
+## Important considerations
+
+- **Averaging RA across the 0°/360° wrap boundary** is numerically incorrect
+  for objects near RA = 0°. The in-source comment acknowledges this
+  ("conversion → mean would be better, but this is cheaper"). For objects whose
+  detections span the wrap, the mean RA will be wrong, and so will all three
+  Cartesian coordinates.
+- **No NaN guard.** If `ra` or `dec` contains any NaN values, `pandas.mean`
+  silently skips them (NaN-aware mean). If *all* values are NaN, the result is
+  `NaN`, which propagates to the three features without raising an exception.
+- **No minimum-length guard.** A single detection is sufficient; the extractor
+  does not fail on one-point light curves.
+- **`fid` is always `None`**, so downstream code that filters features by `fid`
+  must handle `None` explicitly.
+- **`sid` encoding.** When an `AstroObject` carries detections from multiple
+  surveys, `sid` becomes a comma-joined string like `"LSST,ZTF"`. Consumers
+  must not assume `sid` is a scalar survey identifier for these features.
+- **In-place mutation.** `astro_object.features` is replaced by a new
+  `pd.concat` result. Any reference held to the old DataFrame before the call
+  becomes stale.
+- **No version bump mechanism.** `version = "1.0.0"` is a class-level constant.
+  All three features carry the same version string.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `lc_classifier/lc_classifier/features/composites/ztf.py` — `ZTFFeatureExtractor`
+  - `lc_classifier/lc_classifier/features/composites/lsst.py` — LSST composite
+  - `lc_classifier/lc_classifier/features/composites/elasticc.py` — ELAsTiCC composite
+- **Tests:** `lc_classifier/tests/features/test_coordinate_extractor.py`
+- **Other extractors reading the same fields:** any extractor that reads
+  `detections["ra"]` or `detections["dec"]` (e.g. positional cross-match
+  extractors), but no extractor was found to *consume* `Coordinate_x`,
+  `Coordinate_y`, or `Coordinate_z` as inputs.
+- **Downstream consumers of the feature names:** no extractor in the repo reads
+  `Coordinate_x/y/z` from `astro_object.features`; these features are intended
+  as direct model inputs.

--- a/lc_classifier/lc_classifier/features/extractors/docs/dummy_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/dummy_extractor.md
@@ -1,0 +1,91 @@
+# DummyExtractor
+
+A no-op stub extractor that prints a message and performs no computation.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/dummy_extractor.py`
+- **Version:** none — `self.version` is not defined
+- **Base class:** `FeatureExtractor` (abstract base from `lc_classifier.features.core.base`)
+- **External libs:** none
+
+## Purpose / Meaning
+
+`DummyExtractor` exists solely as a development scaffold. It satisfies the
+`FeatureExtractor` interface by implementing `compute_features_single_object`,
+but the body does nothing beyond printing a diagnostic string to stdout. It
+emits no features and mutates nothing on the `AstroObject`. It is not included
+in any composite extractor's production pipeline, though it is imported by
+`LSSTFeatureExtractor` (see Cross-references).
+
+## Input
+
+### Constructor arguments
+
+None. `DummyExtractor` defines no `__init__`, so it inherits the default
+`object.__init__` with no parameters.
+
+### `AstroObject` fields read
+
+None. The implementation ignores the `astro_object` argument entirely.
+
+### Pre-filtering applied
+
+None.
+
+### Valid `unit` values
+
+Not applicable — no photometric data is consumed.
+
+## Output
+
+`DummyExtractor` appends nothing to `astro_object.features`. The method
+returns `None` explicitly, which is consistent with the in-place contract
+documented in `FeatureExtractor.compute_features_single_object` ("This method
+is inplace"), but no in-place mutation occurs either.
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| *(none)*       | —           | No features are produced. |
+
+**Sentinel behavior:** not applicable — no output path exists to short-circuit.
+
+## Underlying library / math
+
+No third-party scientific libraries are used. The only dependency is the
+internal `FeatureExtractor` and `AstroObject` from
+`lc_classifier.features.core.base`.
+
+## Hardcoded values
+
+- The string `" Dummy Extractor called "` — printed to stdout on every
+  call. Baked in, not configurable.
+
+## Important considerations
+
+- **No `self.version`:** Unlike every production extractor, `DummyExtractor`
+  does not set `self.version`. Any downstream code that reads
+  `extractor.version` will raise `AttributeError`.
+- **Side effect — stdout:** Each call prints to stdout unconditionally. In
+  batch processing (`compute_features_batch` iterates over all objects), this
+  produces one print per object with no way to suppress it short of redirecting
+  stdout externally.
+- **Returns `None`, not in-place mutation:** The docstring on
+  `FeatureExtractor.compute_features_single_object` says the method is
+  in-place. `DummyExtractor` returns `None` and leaves `astro_object.features`
+  as the empty `DataFrame` initialised by `AstroObject.__post_init__`.
+- **Not registered in the production pipeline:** `LSSTFeatureExtractor`
+  imports `DummyExtractor` but does not instantiate it inside
+  `_instantiate_extractors`. It is dead import code in that composite.
+- **`AstroObject` contract not verified:** Because no field is accessed,
+  the mandatory column checks (`oid`, `sid`, `fid` in `detections`) enforced
+  by `AstroObject.__post_init__` are the only guard rails; the extractor
+  itself adds none.
+
+## Cross-references
+
+- **Composites that import (but do not use) this extractor:**
+  `lc_classifier/lc_classifier/features/composites/lsst.py` —
+  `LSSTFeatureExtractor` imports `DummyExtractor` at the module level but
+  does not include it in the list returned by `_instantiate_extractors`.
+- **Other extractors that read the same `AstroObject` fields:** not applicable
+  (no fields are read).
+- **Consumers of emitted feature names:** none (no features are emitted).

--- a/lc_classifier/lc_classifier/features/extractors/docs/folded_kim_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/folded_kim_extractor.md
@@ -1,0 +1,111 @@
+# FoldedKimExtractor
+
+Computes two period-folded variability statistics, `Psi_CS` and `Psi_eta`, per photometric band using a period value that must already be present in `astro_object.features`.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/folded_kim_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `numpy`, `pandas` (no additional third-party scientific library; the statistics are computed inline)
+
+## Purpose / Meaning
+
+`Psi_CS` and `Psi_eta` characterise how well the light curve flux varies coherently when folded at the best-fit period. A light curve folded on the correct period will show an ordered, smooth brightness sequence; these two statistics quantify that order. `Psi_CS` is a cumulative-sum range statistic (large when folded brightness drifts monotonically), and `Psi_eta` is the ratio of consecutive-difference variance to total variance (small when folded points change smoothly). Both are useful discriminators between periodic and non-periodic variables and originate in Kim et al. (2014) — see the turbofats implementations `Psi_CS_v2` and `Psi_eta_v2` in `lc_classifier/lc_classifier/features/turbofats/FeatureFunctionLib.py` for the original per-band formulations this extractor is based on.
+
+## Input
+
+### Constructor arguments
+
+| Name    | Type        | Default | Meaning |
+|---------|-------------|---------|---------|
+| `bands` | `List[str]` | —       | Photometric band identifiers to compute features for (e.g. `["g", "r"]`). Required. |
+| `unit`  | `str`       | —       | Unit of the `brightness` column to accept. Must be `"magnitude"` or `"diff_flux"`. Required. Raises `ValueError` otherwise. |
+
+### `AstroObject` fields read
+
+- `features` — must already contain a row with `name == "Multiband_period"`. The value at `features[features["name"] == "Multiband_period"]["value"][0]` is used as the period. An `Exception` is raised if this row is absent.
+- `detections` — columns consumed: `unit`, `brightness`, `fid`, `mjd`, `sid`.
+
+### Pre-filtering applied
+
+1. Rows in `detections` where `unit != self.unit` are dropped.
+2. Rows where `brightness` is `NaN` are dropped.
+3. Per band, if `len(band_detections) <= 2` or `period` is `NaN`, sentinel values are emitted rather than computing.
+
+### Valid `unit` values
+
+`"magnitude"` and `"diff_flux"`. Any other string causes the constructor to raise `ValueError` before any computation occurs.
+
+## Output
+
+Every row appended to `astro_object.features`. Columns: `name`, `value`, `fid`, `sid`, `version`.
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `Psi_CS`       | per band    | Range of the normalised cumulative sum of mean-subtracted brightness values sorted by folded phase. Defined as `max(s) - min(s)` where `s = cumsum(m_i - mean) / (N * sigma)`. Larger values indicate stronger periodic signal. |
+| `Psi_eta`      | per band    | Consecutive-difference variance ratio on the phase-folded, sorted brightness sequence: `sum((m_{i+1} - m_i)^2) / ((N-1) * sigma^2)`. Smaller values indicate a smoother periodic signal. |
+
+**Sentinel value:** `np.nan` is emitted for both features when:
+- the band has 2 or fewer detections after filtering, or
+- `period` is `np.nan`, or
+- `sigma == 0.0` (all brightness values in the band are identical after folding).
+
+## Underlying library / math
+
+No third-party scientific library beyond `numpy` is called. All computation is inline.
+
+**Phase folding:**
+
+```
+folded_time = mod(time, 2 * period) / (2 * period)
+```
+
+The light curve is folded over a window of `2 * period` (two full cycles), not one. This doubles the effective phase window compared to a standard single-period fold. The reason for this choice is not documented in the source; it differs from the turbofats `Psi_CS_v2` / `Psi_eta_v2` implementations (which use `new_time_v2` computed by `PeriodLS_v2`) and from the original Kim et al. formulation that folds over a single period.
+
+**`Psi_CS` formula:**
+
+```
+s_i = cumsum(m_i - mean(m)) / (N * std(m))
+Psi_CS = max(s) - min(s)
+```
+
+**`Psi_eta` formula:**
+
+```
+Psi_eta = sum((m_{i+1} - m_i)^2) / ((N - 1) * std(m)^2)
+```
+
+where indices run over the brightness array sorted by `folded_time` and `std` uses NumPy's default `ddof=0`.
+
+**Note on `std` vs `var`:** `Psi_CS` normalises by `std(m)` while `Psi_eta` normalises by `std(m)^2`. The turbofats `Psi_eta_v2` uses `np.var` (`ddof=0`) directly. Both are equivalent; the extractor computes `sigma = np.std(...)` once and reuses `sigma**2` for the `Psi_eta` denominator.
+
+## Hardcoded values
+
+- `2 * period` — the fold window. Baked in; not tunable via the constructor.
+- `ddof=0` — `np.std` default; affects normalisation. Not tunable.
+- `period` is read from `astro_object.features` at index `[0]` of the filtered series — if there are multiple `Multiband_period` rows, only the first is used (no check for uniqueness).
+
+## Important considerations
+
+- **Execution order dependency:** `FoldedKimExtractor` must run **after** a `PeriodExtractor` (or any extractor that writes `Multiband_period` to `astro_object.features`). In all known composites (`ZTFFeatureExtractor`, `ELAsTiCCFeatureExtractor`, `LSSTFeatureExtractor`) it is placed after `PeriodExtractor` in the `extractors` list. If run standalone or out of order, it raises a bare `Exception` with the message `"Folded Kim extractor was not provided with period data"`.
+- **Fold window is `2 * period`, not `period`:** The standard Kim et al. definition folds over one period. The doubled window means the phase axis spans `[0, 1)` but covers two physical cycles. This is an intentional or accidental deviation from the turbofats reference implementation; downstream consumers should be aware that the feature values are not directly comparable to turbofats `Psi_CS_v2` / `Psi_eta_v2`.
+- **`sigma == 0` guard:** When all brightness values are equal after filtering, both features are set to `np.nan` rather than dividing by zero.
+- **No error handling:** There is no `try/except` block. Any unexpected runtime error (e.g. malformed `detections` DataFrame, missing columns) will propagate as an unhandled exception.
+- **`sid` aggregation:** All unique `sid` values from the filtered detections are sorted and joined with `","` into a single string. Per-band `sid` is not tracked separately.
+- **In-place mutation:** `astro_object.features` is replaced by a `pd.concat` result on every call. If called more than once on the same object, duplicate `Psi_CS` / `Psi_eta` rows will accumulate.
+- **`detections` is not sorted by `mjd`:** The extractor does not sort `detections` before folding. It relies on NumPy's `argsort(folded_time)` to sort brightness by phase, so the original order of rows in `detections` does not matter.
+- **`e_brightness` is never read:** Measurement uncertainties are not used in any of the statistics.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `lc_classifier/lc_classifier/features/composites/ztf.py` — `ZTFFeatureExtractor`, with `unit="magnitude"`.
+  - `lc_classifier/lc_classifier/features/composites/elasticc.py` — `ELAsTiCCFeatureExtractor`, with `unit` passed from composite constructor.
+  - `lc_classifier/lc_classifier/features/composites/lsst.py` — `LSSTFeatureExtractor`, with `unit="magnitude"`.
+- **Extractor that must run first (produces `Multiband_period`):**
+  - `lc_classifier/lc_classifier/features/extractors/period_extractor.py` — `PeriodExtractor`.
+- **Extractor that also reads `Multiband_period` and runs after:**
+  - `lc_classifier/lc_classifier/features/extractors/harmonics_extractor.py` — `HarmonicsExtractor`.
+- **Analogous turbofats implementations (not called by this extractor):**
+  - `Psi_CS_v2` and `Psi_eta_v2` in `lc_classifier/lc_classifier/features/turbofats/FeatureFunctionLib.py`.
+- **Test file:**
+  - `lc_classifier/tests/features/test_folded_kim_feature_extractor.py`.

--- a/lc_classifier/lc_classifier/features/extractors/docs/gp_drw_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/gp_drw_extractor.md
@@ -1,0 +1,124 @@
+# GPDRWExtractor
+
+Fits a Damped Random Walk (DRW) Gaussian Process model per photometric band and returns the inferred amplitude (`GP_DRW_sigma`) and characteristic timescale (`GP_DRW_tau`).
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/gp_drw_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `celerite2`, `scipy.optimize`
+
+## Purpose / Meaning
+
+The DRW (Ornstein-Uhlenbeck) process is a standard stochastic model for AGN variability and is widely used to characterise the smoothness and amplitude of aperiodic light-curve variation. Fitting this model per band yields two physical parameters — the process variance (`GP_DRW_sigma`) and the correlation decay rate (from which the timescale `GP_DRW_tau` is derived) — that help classifiers distinguish AGN from other variable types.
+
+## Input
+
+### Constructor arguments
+
+| Name    | Type        | Default | Meaning                                                          |
+|---------|-------------|---------|------------------------------------------------------------------|
+| `bands` | `List[str]` | —       | Photometric bands to process (e.g. `["g", "r"]` for ZTF).       |
+| `unit`  | `str`       | —       | Brightness unit; must be `"magnitude"` or `"diff_flux"`. Raises `ValueError` otherwise. |
+
+### `AstroObject` fields read
+
+- `detections` — columns: `brightness`, `e_brightness`, `fid`, `mjd`, `unit`, `sid`.
+- `forced_photometry` — **not read**; this extractor uses `astro_object.detections` only.
+- `metadata` — not read.
+
+### Pre-filtering applied
+
+1. Rows where `brightness` is `NaN` are dropped.
+2. Rows whose `unit` column does not match `self.unit` are dropped.
+3. Per band, rows are selected by `fid == band`.
+4. If the resulting per-band detection count is less than `detections_min_len` (= 5), the band is skipped and sentinels are emitted.
+5. `mjd` is shifted so that `min(mjd) == 0`.
+6. Detections are sorted by `mjd` (ascending) — required by celerite2, which raises `ValueError` on unsorted input.
+7. `brightness` is mean-subtracted (zero-mean model assumed).
+
+### Valid `unit` values
+
+`"magnitude"` or `"diff_flux"`. Both composites that use this extractor (`ZTFFeatureExtractor`, `LSSTFeatureExtractor`) pass `unit="diff_flux"`. The `unit` filter is applied before the GP fit, so any detection row in `detections` with a different unit value is silently excluded.
+
+## Output
+
+Every row appended to `astro_object.features`. Columns: `name`, `value`, `fid`, `sid`, `version`.
+
+| Feature `name`  | `fid` scope | Meaning                                                                                  |
+|-----------------|-------------|------------------------------------------------------------------------------------------|
+| `GP_DRW_sigma`  | per band    | Fitted amplitude `a` of the DRW kernel, in units of the input `brightness`. Equals `exp(sol.x[0])` after L-BFGS-B optimisation. |
+| `GP_DRW_tau`    | per band    | Fitted characteristic timescale in days. Equals `1 / exp(sol.x[1])`, i.e. `1 / c` from `RealTerm(a, c)`. |
+
+**Sentinel value:** `np.nan` for both features when the per-band detection count is below `detections_min_len` (5). No sentinel is explicitly emitted when the L-BFGS-B optimiser fails to converge; in that case `sol.x` will contain the best iterates reached and the returned values will be non-NaN but potentially unreliable.
+
+`sid` is computed as a comma-joined, sorted string of all unique `sid` values present in the (already unit-filtered) detections — not scoped per band.
+
+## Underlying library / math
+
+### `celerite2.terms.RealTerm`
+
+- **Function:** `celerite2.terms.RealTerm(a=..., c=...)`
+- **Algorithm:** Defines the simplest celerite covariance kernel:
+
+  k(τ) = a · exp(−c · τ)
+
+  This is the Ornstein-Uhlenbeck (DRW) kernel. The parameter `a` is the amplitude (variance at zero lag) and `c` is the inverse timescale (decay rate). `c > 0` is required for a valid covariance function; the library's own docstring warns that this term "will generally behave poorly" and that `SHOTerm` should be preferred for most use cases — it is used here deliberately to implement the DRW model.
+- **Coefficients returned by `get_coefficients()`:** `(array([a]), array([c]), empty, empty, empty, empty)` — a single real term, no complex component.
+
+### `celerite2.GaussianProcess.compute`
+
+- **Function:** `celerite2.numpy.GaussianProcess.compute(t, *, diag=None, quiet=False)`
+- **Algorithm:** Builds the celerite matrices `(c, a, U, V)` from the kernel, then performs a Cholesky factorisation of the `N×N` GP covariance matrix using the semi-separable (rank-1 for `RealTerm`) structure. Complexity is O(N) in both time and memory for a rank-J kernel.
+- **`quiet=True`:** When the Cholesky factorisation fails (e.g. due to numerical non-positive-definiteness), instead of raising `LinAlgError`, the log-determinant is set to `-inf` and `_norm` is set to `inf`. This silences the error — `log_likelihood` will then return `-inf`, which drives the optimiser away from that parameter region.
+- **Dtype requirement:** All arrays are cast to `float64` C-contiguous arrays internally (`_as_tensor` calls `np.ascontiguousarray(..., dtype=np.float64)`).
+- **Sort requirement:** `_check_sorted` raises `ValueError` if `np.any(np.diff(t) < 0)`. The extractor satisfies this by calling `sort_values("mjd")` before passing times to the GP.
+
+### `celerite2.GaussianProcess.log_likelihood`
+
+- **Function:** `gp.log_likelihood(y)`
+- **Returns:** The marginal log-likelihood of the GP model:
+
+  log p(y) = −0.5 · (y − μ)ᵀ K⁻¹ (y − μ) − 0.5 · log|K| − (N/2) · log(2π)
+
+  where `K = kernel_matrix + diag(e_brightness²)`, `μ = 0` (mean-subtracted brightness), and the solve uses the pre-factored Cholesky. Returns a scalar `float64`.
+
+### `scipy.optimize.minimize` (L-BFGS-B)
+
+- **Function:** `scipy.optimize.minimize(neg_log_like, x0, method="L-BFGS-B", bounds=..., args=...)`
+- **Algorithm:** Limited-memory BFGS with box constraints. Minimises the negative log-likelihood over two parameters in log-space: `params = [log(a), log(c)]`.
+- **Returns:** `OptimizeResult`; `sol.x` contains the optimal log-space parameters. `np.exp(sol.x)` gives `[a_opt, c_opt]`.
+- **No convergence check:** The extractor does not inspect `sol.success` or `sol.fun`. If the optimiser terminates without converging, the last `sol.x` is used silently.
+
+## Hardcoded values
+
+| Value | Location | Tunable? | Meaning |
+|-------|----------|----------|---------|
+| `detections_min_len = 5` | `__init__` | No (attribute, but no constructor arg) | Minimum per-band detections required to attempt a GP fit. |
+| `a=1.0, c=10.0` | `kernel = terms.RealTerm(a=1.0, c=10.0)` | No | Initial kernel used only to instantiate `GaussianProcess`; overwritten at every optimiser call before `compute`. Has no effect on results. |
+| `mean=0.0` | `celerite2.GaussianProcess(kernel, mean=0.0)` | No | GP mean function fixed at zero. The extractor mean-subtracts brightness before calling the GP, so this is consistent. |
+| `initial_params = np.zeros((2,))` | `minimize` call | No | Initial log-space parameters: `log(a)=0 → a=1`, `log(c)=0 → c=1`. |
+| `bounds=[[-10.0, 19.0], [-6.0, 6.0]]` | `minimize` call | No | Log-space bounds for `a` and `c`. In linear space: `a ∈ [exp(−10), exp(19)] ≈ [4.5e-5, 1.8e8]`; `c ∈ [exp(−6), exp(6)] ≈ [0.0025, 403]` (timescale `τ = 1/c ∈ [0.0025, 403]` days). |
+| `method="L-BFGS-B"` | `minimize` call | No | Optimisation algorithm. |
+
+## Important considerations
+
+- **No convergence guard:** `sol.success` is never checked. Silent non-convergence will produce non-NaN outputs that may be physically meaningless. Downstream consumers cannot distinguish converged from non-converged fits.
+- **`quiet=True` in `gp.compute`:** A Cholesky failure during the optimisation does not raise an exception; it sets the log-likelihood to `-inf`. This is intentional — it pushes the optimiser away from ill-conditioned parameter regions — but it means all numerical errors during the fit are silently absorbed.
+- **Stateful `gp` object inside the closure:** The `gp` object is created once per band and mutated on every objective function evaluation inside `neg_log_like` (kernel and mean are reassigned). This is safe for single-threaded use but not thread-safe.
+- **Mean subtraction is irreversible:** `detections_band["brightness"] -= np.mean(...)` operates on a `.copy()`, so the original `astro_object.detections` is not mutated.
+- **`sid` is multi-band:** The `sid` column in the output is derived from all (unit-filtered) detections across all bands, not from the per-band subset. All feature rows for an object share the same `sid` string.
+- **`GP_DRW_tau` interpretation:** The timescale is `1 / c` (inverse of the kernel decay rate), in the same time unit as `mjd` (days). It is *not* related to the `tau` parameter of `SHOTerm` or `SHOTerm`'s reparameterisation.
+- **`RealTerm` positive-definiteness:** The celerite2 documentation notes that `RealTerm` should be used only by advanced users who keep both `a` and `c` strictly positive. The optimisation bounds keep both in positive territory (log-space lower bounds ensure the exponentiated values are > 0), but the optimiser is not constrained to strictly positive values in the interior.
+- **Input dtype:** `detections_band["mjd"].values` and related arrays are passed as NumPy arrays; celerite2 casts them to `float64` internally. If the source DataFrame has `float32` columns, a silent copy/cast occurs.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `lc_classifier/lc_classifier/features/composites/ztf.py` — `ZTFFeatureExtractor`, instantiated with `bands=["g","r"]` and `unit="diff_flux"`.
+  - `lc_classifier/lc_classifier/features/composites/lsst.py` — `LSSTFeatureExtractor`, instantiated with `bands=["u","g","r","i","z","y"]` and `unit="diff_flux"`.
+- **Consumers of `GP_DRW_sigma` / `GP_DRW_tau`:**
+  - `lc_anomaly_step/tests/mockdata/features_elasticc.py`, `features_ztf.py` — mock feature schemas include these names.
+  - `lc_classification_step/tests/mockdata/features_ztf.py`, `features_elasticc.py` — same.
+  - `alerce_classifiers/alerce_classifiers/messi/utils.py`, `anomaly/utils.py` — classifier utilities that reference these feature names.
+  - `libs/db-plugins-multisurvey/db_plugins/db/sql/_initial_data_pipeline.py`, `_initial_data.py` — database schema definitions listing these feature names.
+- **Tests:** `lc_classifier/tests/features/test_gp_drw_extractor.py`

--- a/lc_classifier/lc_classifier/features/extractors/docs/harmonics_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/harmonics_extractor.md
@@ -1,0 +1,144 @@
+# HarmonicsExtractor
+
+Fits a truncated Fourier series to a folded light curve and extracts per-band harmonic amplitudes, relative phases, fit MSE, and reduced chi-squared.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/harmonics_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `numpy`, `pandas` (no additional third-party scientific library; the Fourier fit is implemented inline)
+
+## Purpose / Meaning
+
+A periodic light curve can be represented as a sum of sinusoids at harmonics of the fundamental frequency. The amplitudes (`Harmonics_mag_*`) and relative phases (`Harmonics_phase_*`) of those harmonics characterise the light-curve shape independently of its brightness. These shape descriptors are powerful discriminants between variable-star classes (e.g. RR Lyrae vs. eclipsing binaries vs. Cepheids). The goodness-of-fit statistics (`Harmonics_mse`, `Harmonics_chi`) indicate how well the periodic model describes the data and flag cases where the period is unreliable or the light curve is noisy.
+
+## Input
+
+### Constructor arguments
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — (required) | Photometric bands to process (e.g. `["g","r"]`). |
+| `unit` | `str` | — (required) | Observation unit; must be `"magnitude"` or `"diff_flux"`. Controls `error_tol`. |
+| `use_forced_photo` | `bool` | — (required) | If `True`, concatenates `forced_photometry` detections with `detections` before processing. |
+| `n_harmonics` | `int` | `7` | Number of Fourier harmonics to fit. Determines the model degrees of freedom (`2*n_harmonics + 1`) and the number of output features. |
+
+### `AstroObject` fields read
+
+- `detections` — columns: `mjd`, `brightness`, `e_brightness`, `fid`, `unit`, `sid`. The `sid` column is read to build the composite survey-ID string attached to every output feature row.
+- `forced_photometry` — when `use_forced_photo=True`, concatenated with `detections` along `axis=0`. Expected to carry the same columns.
+- `features` — the pre-existing feature table is read to retrieve `Multiband_period` (the fundamental period in days), which must already be present. If it is absent, `compute_features_single_object` raises an `Exception` immediately.
+
+### Pre-filtering applied
+
+1. If `use_forced_photo=True` and `astro_object.forced_photometry is not None`, forced-photometry rows are appended to detections.
+2. Rows whose `unit` column does not match `self.unit` are dropped.
+3. Rows where `brightness` is `NaN` are dropped.
+4. Rows where `e_brightness <= 0.0` are dropped.
+5. The remaining observations are split per band; no explicit `mjd` sort is applied (order is preserved from the input DataFrames).
+
+### Valid `unit` values
+
+| Value | Effect |
+|-------|--------|
+| `"magnitude"` | Sets `error_tol = 1e-2`. Raises `ValueError` at construction for any other string. |
+| `"diff_flux"` | Sets `error_tol = 1e-3`. |
+
+`error_tol` is added to each per-observation error in the chi-squared denominator to prevent division by very small numbers (see *Hardcoded values*).
+
+## Output
+
+One set of feature rows is appended per band in `self.bands`. The `fid` column is set to the band string; `sid` is the sorted, comma-joined list of unique survey IDs found in `detections`.
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `Harmonics_mag_1` | per band | Amplitude of the fundamental harmonic: `sqrt(a_1^2 + b_1^2)`. |
+| `Harmonics_mag_2` … `Harmonics_mag_<n_harmonics>` | per band | Amplitudes of the 2nd through N-th harmonics. |
+| `Harmonics_phase_2` … `Harmonics_phase_<n_harmonics>` | per band | Relative phase of harmonic k with respect to the fundamental: `(phi_k - k*phi_1) mod 2pi` (radians). No `Harmonics_phase_1` is emitted. |
+| `Harmonics_mse` | per band | Mean squared error between the fitted model and the observed brightness values. |
+| `Harmonics_chi` | per band | Reduced chi-squared: `sum((fit - obs)^2 / (err + error_tol)^2) / (N - (1 + 2*n_harmonics))`. |
+
+**Total rows per band:** `2 + n_harmonics + (n_harmonics - 1)` = `2*n_harmonics + 1`. With the default `n_harmonics=7`: 15 rows per band.
+
+**Sentinel value:** `np.nan` is written for all features of a given band when either:
+- `Multiband_period` is `np.nan`, or
+- the number of band observations after filtering is strictly less than `self.degrees_of_freedom` (`2*n_harmonics + 1 = 15` by default).
+
+`Harmonics_chi` is additionally set to `np.nan` when `len(fitted_magnitude) - (1 + 2*n_harmonics) < 1`, i.e. when the denominator of the reduced chi-squared would be zero or negative.
+
+## Underlying library / math
+
+No dedicated periodogram library is called. The fit is implemented entirely with `numpy`:
+
+**Design matrix construction**
+
+```
+omega[:, 0]        = 1                                  (DC / mean term)
+omega[:, 1..N]     = cos(2*pi*k*f0*t),  k = 1..n_harmonics
+omega[:, N+1..2N]  = sin(2*pi*k*f0*t),  k = 1..n_harmonics
+```
+
+where `f0 = 1 / Multiband_period` and `t` are the observation times in MJD.
+
+**Weighted least-squares solution**
+
+Each row of the design matrix and the brightness vector is scaled by `1/error` (inverse-error weighting), then solved via `numpy.linalg.pinv`:
+
+```python
+w_a = (1/error).reshape(-1,1) * omega   # shape (N_obs, 1 + 2*n_harmonics)
+w_b = (brightness / error).reshape(-1,1)
+coeffs = pinv(w_a) @ w_b                # shape (1 + 2*n_harmonics,)
+```
+
+`numpy.linalg.pinv` uses the Moore-Penrose pseudoinverse (SVD-based). This is numerically safe when `w_a` is rank-deficient but may be slow for large `N_obs`.
+
+**Amplitude and phase extraction**
+
+```python
+coef_mag[k] = sqrt(a_k^2 + b_k^2)                        # k = 1..n_harmonics
+coef_phi[k] = arctan2(b_k, a_k)                           # k = 1..n_harmonics
+# relative phase (phi_k - k*phi_1), then mod 2pi for k >= 2
+coef_phi = (coef_phi - coef_phi[0] * arange(1, n+1))[1:] % (2*pi)
+```
+
+The phase formula subtracts `k * phi_1` from each harmonic's absolute phase, expressing all phases relative to the fundamental. The modulo wraps into `[0, 2*pi)`.
+
+## Hardcoded values
+
+| Value | Location | Tunable? | Effect |
+|-------|----------|----------|--------|
+| `error_tol = 1e-2` | constructor, `unit == "magnitude"` | No (unit-derived) | Added to each `e_brightness` in chi-squared denominator to prevent near-zero division. |
+| `error_tol = 1e-3` | constructor, `unit == "diff_flux"` | No (unit-derived) | Same purpose, smaller floor for flux-space errors. |
+| `degrees_of_freedom = 2*n_harmonics + 1` | constructor | Derived from `n_harmonics` | Minimum observations required before fitting; also the denominator offset in reduced chi-squared. |
+| `10**-2` (= `0.01`) | `compute_features_single_object` line 65 | No | Added to every `e_brightness` value *before* computing `inverr` (`1/error`). This is separate from `error_tol` and unconditionally inflates measurement errors regardless of `unit`. |
+| `2 * np.pi` | design matrix construction | No | Period-to-angular-frequency conversion constant. |
+| `n_harmonics = 7` | constructor default | Yes (constructor arg) | Controls model complexity and number of output features. |
+
+**Note on the double error floor:** there are two independent error-inflation mechanisms. `10**-2` (line 65) is always added to raw `e_brightness` before inversion (`inverr = 1/error`), affecting both the weighted fit and the chi-squared numerator. `error_tol` is only added in the chi-squared denominator. For `unit == "magnitude"` both are `0.01`; for `unit == "diff_flux"` the denominator uses `0.001` but the numerator/fit still uses the `0.01` floor. This asymmetry is undocumented in the source.
+
+## Important considerations
+
+- **Ordering dependency.** `HarmonicsExtractor` must run *after* `PeriodExtractor` in any composite pipeline. If `Multiband_period` is absent from `astro_object.features`, `compute_features_single_object` raises an `Exception` (not returns NaN). The composites `ZTFFeatureExtractor`, `LSSTFeatureExtractor`, and `ElasticcFeatureExtractor` all satisfy this ordering constraint.
+
+- **Period read bug risk.** The period is retrieved via `period["value"][0]`, where `0` is the integer *index label*, not a positional index. If the DataFrame index does not contain `0` (e.g. after a concat), this will raise a `KeyError`. It should be `.iloc[0]`.
+
+- **No `mjd` sort.** The extractor does not sort by `mjd`. The Fourier design matrix is built in the order rows arrive. This is safe for the algebraic fit but worth noting for any future sequential processing layered on top.
+
+- **In-place mutation.** `compute_features_single_object` appends rows directly to `astro_object.features` via `pd.concat` and reassigns the attribute. If the extractor raises mid-band (e.g. on the KeyError above), previously appended bands are already committed.
+
+- **Bands with no data.** If a band has no observations after filtering, `len(band_observations) < self.degrees_of_freedom` is `True` (since 0 < 15), so NaN sentinels are written without error.
+
+- **Forced photometry `None` guard.** If `use_forced_photo=True` but `astro_object.forced_photometry is None`, the extractor silently proceeds with detections only. No warning is emitted.
+
+- **`sid` construction.** `sid` is assembled from `detections["sid"].unique()` only — forced-photometry survey IDs are not included even when `use_forced_photo=True`. Whether this is intentional is unclear from the source.
+
+- **Phase interpretation.** `Harmonics_phase_k` is `(phi_k - k*phi_1) mod 2pi` in radians, with `k` starting at 2. There is no `Harmonics_phase_1` feature. Consumers should be aware that the phase wraps; a value near `0` and a value near `2*pi` represent nearly the same phase relationship.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `ZTFFeatureExtractor` (`composites/ztf.py`) — `unit="magnitude"`, `use_forced_photo=True`, bands `["g","r"]`
+  - `LSSTFeatureExtractor` (`composites/lsst.py`) — `unit="magnitude"`, `use_forced_photo=True`, bands `["u","g","r","i","z","y"]`
+  - `ElasticcFeatureExtractor` (`composites/elasticc.py`) — `unit="diff_flux"`, `use_forced_photo=True`, bands `["u","g","r","i","z","Y"]`
+- **Upstream dependency:** `PeriodExtractor` (`extractors/period_extractor.py`) — emits `Multiband_period`, which `HarmonicsExtractor` reads as its fundamental frequency.
+- **Parallel dependent:** `FoldedKimExtractor` (`extractors/folded_kim_extractor.py`) — also reads `Multiband_period` from `astro_object.features` using the same pattern.
+- **Tests:** `tests/features/test_harmonics_feature_extractor.py`, `tests/features/test_ztf_preprocessor.py`

--- a/lc_classifier/lc_classifier/features/extractors/docs/mhps_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/mhps_extractor.md
@@ -1,0 +1,129 @@
+# MHPSExtractor
+
+Computes Mexican Hat Power Spectrum (MHPS) features — integrated power at two timescales and their ratio — for each photometric band of a light curve.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/mhps_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `mhps` (version 0.1.1, Cython extension; paper: https://arxiv.org/abs/1207.5825)
+
+## Purpose / Meaning
+
+The Mexican Hat Power Spectrum measures the integrated power of a light curve at two user-defined timescales (`t1`, `t2`) by convolving the light curve with Mexican Hat (Ricker wavelet) kernels of width `t1` (low-frequency / long-timescale) and `t2` (high-frequency / short-timescale). The ratio `MHPS_low / MHPS_high` discriminates between sources whose variability is dominated by long-timescale structure (e.g. long-period variables, active galactic nuclei) versus short-timescale structure (e.g. fast transients, eclipsing binaries). The `MHPS_PN_flag` signals when Poisson noise dominates the convolved power, which indicates either a photometrically quiet source or insufficient data.
+
+## Input
+
+### Constructor arguments
+
+| Name   | Type        | Default   | Meaning |
+|--------|-------------|-----------|---------|
+| `bands` | `List[str]` | (required) | Photometric band identifiers to process (e.g. `["g", "r"]` for ZTF, `["u","g","r","i","z","y"]` for LSST). |
+| `unit`  | `str`       | (required) | Brightness unit; must be `"magnitude"` or `"diff_flux"`. Raises `ValueError` if any other value is passed. |
+| `t1`   | `float`     | `100.0`   | Long-timescale kernel half-width in days (low-frequency probe). |
+| `t2`   | `float`     | `10.0`    | Short-timescale kernel half-width in days (high-frequency probe). |
+| `dt`   | `float`     | `3.0`     | Stored as `self.dt` but **never passed** to `mhps.statistics` or `mhps.flux_statistics`. The library uses its own internal default for the convolution time step when `dt` is omitted. This parameter is dead code in the current implementation. |
+
+### `AstroObject` fields read
+
+- `detections` — columns: `mjd`, `brightness`, `e_brightness`, `fid`, `unit`, `sid`.
+
+`forced_photometry` is not read by this extractor.
+
+### Pre-filtering applied
+
+1. Rows where `detections["unit"] != self.unit` are dropped.
+2. Rows where `detections["brightness"]` is `NaN` are dropped.
+3. Per band: rows where `detections["fid"] != band` are dropped.
+4. Per band: detections are sorted ascending by `mjd` (in-place on a `.copy()`).
+
+### Valid `unit` values
+
+- `"magnitude"`: arrays are cast to `np.double` before calling `mhps.statistics`.
+- `"diff_flux"`: arrays are cast to `np.float32` before calling `mhps.flux_statistics`. The compiled extension enforces `float32` for `flux_statistics`; passing `float64` raises a `ValueError: Buffer dtype mismatch`.
+
+## Output
+
+Every row appended to `astro_object.features` has columns `name`, `value`, `fid`, `sid`, `version`.
+
+`sid` is set to a comma-joined, sorted string of all unique `sid` values present in the (unit-filtered) detections — not band-specific.
+
+### When `t1 == 100.0` and `t2 == 10.0` (default case)
+
+| Feature `name`    | `fid` scope | Meaning |
+|-------------------|-------------|---------|
+| `MHPS_ratio`      | per band    | `MHPS_low / MHPS_high`: ratio of integrated power at low frequency to high frequency. Values >> 1 indicate slow variability; values << 1 indicate fast variability. |
+| `MHPS_low`        | per band    | Integrated power (sigma-clipped) at the long-timescale kernel (`t1`). Units depend on the brightness unit. |
+| `MHPS_high`       | per band    | Integrated power (sigma-clipped) at the short-timescale kernel (`t2`). |
+| `MHPS_non_zero`   | per band    | Count of time bins with non-zero power in the convolved spectrum (proxy for number of usable epochs after internal filtering). |
+| `MHPS_PN_flag`    | per band    | Integer flag: `0` = signal dominates; `1` = Poisson noise dominates (or insufficient data relative to kernel scale). |
+
+### When `t1 != 100.0` or `t2 != 10.0` (non-default timescales)
+
+Only three features are emitted per band; `non_zero` and `pn_flag` are silently discarded:
+
+| Feature `name`                      | `fid` scope | Meaning |
+|-------------------------------------|-------------|---------|
+| `MHPS_ratio_{int(t1)}_{int(t2)}`    | per band    | Power ratio, as above, with timescale values embedded in the name (e.g. `MHPS_ratio_365_30`). |
+| `MHPS_low_{int(t1)}`                | per band    | Low-frequency integrated power (e.g. `MHPS_low_365`). |
+| `MHPS_high_{int(t2)}`               | per band    | High-frequency integrated power (e.g. `MHPS_high_30`). |
+
+### Sentinel values
+
+All five outputs from `mhps.statistics` / `mhps.flux_statistics` are `np.nan` when:
+- The band has zero detections after pre-filtering (the extractor short-circuits and assigns `np.nan` to all five variables before calling the library).
+- The library itself returns all-`nan`: observed when the number of detections is too small relative to the kernel half-width, or when the time baseline is shorter than the kernel scale. From empirical testing with two observations over a 1-day span against `t1=100, t2=10`, all outputs are `nan`.
+
+## Underlying library / math
+
+### `mhps.statistics` (magnitude mode)
+
+- **Function:** `mhps.statistics(mag, magerr, time, t1, t2[, dt[, mag0[, epsilon]]])`
+- **Algorithm:** Mexican Hat Power Spectrum — convolves the magnitude time series with two Mexican Hat (Ricker wavelet) kernels of half-widths `t1` (days) and `t2` (days) on a uniform time grid, applies sigma-clipping to the resulting power spectrum, and integrates the clipped power. The reference paper is Elorrieta et al. 2013, cited in the package metadata as https://arxiv.org/abs/1207.5825.
+- **Input dtypes:** `mag`, `magerr`, `time` must be `np.double` (float64). Mismatched sizes raise `ValueError: mag, magerr and time array should be the same size`.
+- **Returns:** 5-tuple `(ratio, Ik2_low_freq, Ik2_high_freq, non_zero, PN_flag)`.
+  - `ratio` = `Ik2_low_freq / Ik2_high_freq` (confirmed by direct calculation).
+  - `Ik2_low_freq`: sigma-clipped integrated power at scale `t1`.
+  - `Ik2_high_freq`: sigma-clipped integrated power at scale `t2`.
+  - `non_zero`: integer count of time bins with non-zero power (in practice equals the number of input observations when the baseline is sufficient).
+  - `PN_flag`: `0` or `1`; `1` signals Poisson-noise-dominated regime.
+- **Library defaults inherited:** When `dt`, `mag0`, and `epsilon` are omitted, the library applies its own internal defaults. The extractor never passes `dt` despite storing `self.dt`.
+
+### `mhps.flux_statistics` (diff_flux mode)
+
+- **Function:** `mhps.flux_statistics(flux, fluxerr, time, t1, t2)`
+- **Algorithm:** Same MHPS algorithm adapted for flux (difference-image photometry). Internally calls `_flux_statistics32`.
+- **Input dtypes:** `flux`, `fluxerr`, `time` must be `np.float32`. Passing `float64` raises `ValueError: Buffer dtype mismatch`.
+- **Returns:** same 5-tuple `(ratio, Ik2_low_freq, Ik2_high_freq, non_zero, PN_flag)`.
+- **Error message on size mismatch:** `flux, fluxerr and time array should be the same size`.
+
+### `mhps.sigma_clip`
+
+Used internally by the library (not called directly by the extractor). Operates on `float32` arrays; passing `float64` raises `ValueError`.
+
+## Hardcoded values
+
+- `valid_units = ["magnitude", "diff_flux"]` — constructor guard; baked in.
+- `np.double` cast for `unit == "magnitude"` — baked in; required by the C extension.
+- `np.float32` cast for `unit == "diff_flux"` — baked in; required by the C extension.
+- Feature naming branch `if self.t1 == 100.0 and self.t2 == 10.0` — the default-timescale names (`MHPS_ratio`, `MHPS_low`, `MHPS_high`, `MHPS_non_zero`, `MHPS_PN_flag`) are emitted only for the exact floating-point values `100.0` and `10.0`. Any deviation (e.g. `t1=100.1`) silently switches to the parametric naming scheme and drops `non_zero` and `pn_flag` from the output.
+- `self.dt = 3.0` — stored but never forwarded to the library; effectively dead code.
+
+## Important considerations
+
+- **`dt` is never used.** The constructor accepts and stores `dt` (default `3.0`) with a `# TODO: check extra params of mhps.statistics` comment, but neither `mhps.statistics` nor `mhps.flux_statistics` is called with it. The library silently applies its own internal default for the time-grid step size.
+- **`non_zero` and `pn_flag` are silently dropped for non-default timescales.** When `t1 != 100.0` or `t2 != 10.0`, the library still returns these values but the extractor discards them without warning.
+- **Empty band short-circuit.** If a band has no detections after filtering, the extractor sets all five outputs to `np.nan` and still appends feature rows. This means downstream consumers always receive exactly 5 (or 3) rows per band; they should check for `NaN` rather than the absence of a row.
+- **`sid` aggregation.** `sid` is derived from all unit-filtered detections across all bands, not per-band. All feature rows for the object share the same `sid` string.
+- **Dtype traps.** `mhps.flux_statistics` will raise `ValueError` at runtime if `brightness` or `e_brightness` contains values that cannot be safely cast to `float32` (overflow). The extractor does not guard against this.
+- **Time baseline vs. kernel scale.** Results are `nan` when the observation time span is shorter than `t1`. With `t1=365`, a light curve shorter than ~1 year is likely to yield all-`nan` output for the low-frequency features.
+- **No `min_length` guard.** Unlike some other extractors, `MHPSExtractor` does not enforce a minimum number of observations; the library itself returns `nan` for very short series.
+- **Stateless between calls.** The extractor holds no mutable state from one `compute_features_single_object` call to the next; it is safe to reuse across objects.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `ZTFFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/ztf.py`): instantiates `MHPSExtractor(bands, unit="diff_flux")` (defaults `t1=100, t2=10`) and `MHPSExtractor(bands, unit="diff_flux", t1=365.0, t2=30.0)`.
+  - `LSSTFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/lsst.py`): same two instances as ZTF.
+  - `ElasticcFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/elasticc.py`): instantiates a single `MHPSExtractor(bands, unit)` with default timescales.
+- **Other extractors reading the same fields:** any extractor that reads `detections["brightness"]`, `detections["mjd"]`, `detections["e_brightness"]`, or `detections["fid"]` — e.g. `TurboFatsExtractor`, `HarmonicsExtractor`, `FoldedKimExtractor`.
+- **Consumers of emitted feature names:** no other extractor in the repo reads `MHPS_*` features from `astro_object.features`. These features feed directly into downstream classification models.

--- a/lc_classifier/lc_classifier/features/extractors/docs/panstarrs_feature_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/panstarrs_feature_extractor.md
@@ -1,0 +1,97 @@
+# PanStarrsFeatureExtractor
+
+Extracts static cross-match features from PanSTARRS-1 photometric catalogue data stored in an object's metadata: star-galaxy score, nearest-source distance, and three optical colours.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/panstarrs_feature_extractor.py`
+- **Version:** `1.0.1`
+- **Base class:** `FeatureExtractor` (abstract, from `lc_classifier.features.core.base`)
+- **External libs:** none — pure NumPy / pandas arithmetic
+
+## Purpose / Meaning
+
+PanSTARRS-1 provides pre-computed photometry for static sky sources cross-matched against the transient. The star-galaxy score (`sgscore1`) and angular separation (`distpsnr1`) help distinguish between stellar and extended host-galaxy counterparts. The three colours (`ps_g-r`, `ps_r-i`, `ps_i-z`) characterise the spectral energy distribution of the nearest static source, which is informative for host-galaxy typing and for distinguishing nuclear transients from variable stars.
+
+## Input
+
+### Constructor arguments
+
+None. The constructor only populates `self.required_metadata`; there are no user-tunable parameters.
+
+### `AstroObject` fields read
+
+- `metadata` — a `pd.DataFrame` with columns `name` and `value`. The extractor looks up these six rows by `name`:
+
+  | `metadata` row `name` | Meaning |
+  |-----------------------|---------|
+  | `sgscore1`            | Star-galaxy score for the nearest PanSTARRS source (0 = galaxy, 1 = star) |
+  | `distpsnr1`           | Angular separation to the nearest PanSTARRS source (arcsec) |
+  | `sgmag1`              | PanSTARRS g-band PSF magnitude of the nearest source |
+  | `srmag1`              | PanSTARRS r-band PSF magnitude of the nearest source |
+  | `simag1`              | PanSTARRS i-band PSF magnitude of the nearest source |
+  | `szmag1`              | PanSTARRS z-band PSF magnitude of the nearest source |
+
+- `detections` — not read for any numerical computation, but its length is checked to decide whether to emit `np.nan` for scores and colours.
+- `features` — read and concatenated with the new rows (mutated in-place via `pd.concat`).
+
+### Pre-filtering applied
+
+1. **Metadata completeness check:** if any of the six required metadata names is absent from `metadata["name"]`, all five output features are emitted as `np.nan` immediately.
+2. **Validity guards on scores:** if `sgscore1 < 0` or `distpsnr1 < 0`, both are replaced with `np.nan`.
+3. **Empty-detection guard (scores):** if `len(astro_object.detections) == 0`, `sgscore1` and `distpsnr1` are set to `np.nan`.
+4. **Colour sentinel guard:** each colour is set to `np.nan` if either of its two constituent magnitudes is `< -30.0`.
+5. **Empty-detection guard (colours):** if `len(astro_object.detections) == 0`, all three colours are set to `np.nan`.
+
+### Valid `unit` values
+
+This extractor does not read photometric brightness or use a `unit` parameter. It only reads catalogue metadata values.
+
+## Output
+
+All rows are appended to `astro_object.features` (mutated in-place via `pd.concat`). The `fid` column is always `None` (features are band-agnostic). The `sid` column is always `"panstarrs"`.
+
+| Feature `name` | `fid`  | `sid`       | Meaning |
+|----------------|--------|-------------|---------|
+| `sgscore1`     | `None` | `panstarrs` | Star-galaxy classifier score for the nearest PanSTARRS-1 source; range ~[0, 1] |
+| `distpsnr1`    | `None` | `panstarrs` | Angular separation in arcsec to the nearest PanSTARRS-1 source |
+| `ps_g-r`       | `None` | `panstarrs` | g − r colour (magnitudes) of the nearest PanSTARRS-1 source |
+| `ps_r-i`       | `None` | `panstarrs` | r − i colour (magnitudes) of the nearest PanSTARRS-1 source |
+| `ps_i-z`       | `None` | `panstarrs` | i − z colour (magnitudes) of the nearest PanSTARRS-1 source |
+
+**Sentinel:** `np.nan` is emitted for any feature whose input values fail the guards listed above.
+
+**Short-circuit condition:** if the six required metadata fields are not all present, all five features are emitted as `np.nan` and the colour computation is skipped entirely.
+
+## Underlying library / math
+
+No third-party scientific library is invoked. All computation is direct arithmetic on scalar values read from `astro_object.metadata`:
+
+- `ps_g-r = sgmag1 - srmag1`
+- `ps_r-i = srmag1 - simag1`
+- `ps_i-z = simag1 - szmag1`
+
+NumPy is imported but used only for `np.nan`. pandas is used for DataFrame construction and row filtering.
+
+## Hardcoded values
+
+| Value | Location | Tunable? | Meaning |
+|-------|----------|----------|---------|
+| `< 0` threshold on `sgscore1` and `distpsnr1` | line 37 | No | Treats negative catalogue values as invalid sentinels; replaces with `np.nan` |
+| `< -30.0` threshold on each band magnitude | lines 49–62 | No | Treats magnitudes below −30 as missing/invalid (common ZTF/PanSTARRS sentinel for non-detections); replaces the corresponding colour with `np.nan` |
+| `"panstarrs"` as `sid` | line 76 | No | Survey identifier hard-wired into every output row |
+
+## Important considerations
+
+- **No detections needed for features, but emptiness is checked:** the extractor does not read any photometric time-series, yet it gates all outputs on `len(astro_object.detections) == 0`. If there are zero detections, every feature is `np.nan` even if the metadata is fully populated and valid.
+- **Metadata format dependency:** the extractor accesses `metadata` as a long-format DataFrame with `name` and `value` columns. A wide-format or differently named metadata table will cause a `KeyError` or return `np.nan` via the completeness check.
+- **`[0]` indexing is unsafe:** `metadata[metadata["name"] == "sgscore1"]["value"].values[0]` will raise `IndexError` if a required name appears zero times in `metadata`. The completeness check (`field_intersection`) guards this only if the set of present names is a strict subset; if a name appears but its row has no `value`, a downstream error is still possible.
+- **Multiple rows with the same `name`:** if a metadata field appears more than once, `values[0]` silently uses the first occurrence with no warning.
+- **Mutation:** `astro_object.features` is replaced in-place via `pd.concat`. If the original `features` DataFrame was referenced externally, the external reference is now stale.
+- **`fid = None`:** downstream classifiers that filter features by `fid` must account for `None` (not `np.nan` or an integer band code) in these rows.
+- **`lru_cache` import is unused:** `functools.lru_cache` is imported but never applied in this file.
+
+## Cross-references
+
+- **Composite that includes this extractor:** `ZTFFeatureExtractor` in `lc_classifier/lc_classifier/features/composites/ztf.py` — `PanStarrsFeatureExtractor()` is instantiated with no arguments and run as part of the full ZTF feature pipeline.
+- **Metadata source:** `lc_classifier/lc_classifier/utils.py` populates the six PanSTARRS metadata fields (`sgscore1`, `distpsnr1`, `sgmag1`, `srmag1`, `simag1`, `szmag1`) from a cross-match result (`xmatch`) when constructing an `AstroObject`.
+- **Other extractors reading `metadata`:** `AllwiseColorsFeatureExtractor` and `CoordinateExtractor` also read `astro_object.metadata` for catalogue cross-match or position fields.
+- **Downstream consumers of feature names:** `lc_classifier/lc_classifier/utils.py` references `sgscore1` and `distpsnr1` as cross-match input fields, not as downstream consumers of the extracted features. No other file in the repo was found consuming `ps_g-r`, `ps_r-i`, or `ps_i-z` by name — these are expected to feed the final classifier model directly.

--- a/lc_classifier/lc_classifier/features/extractors/docs/period_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/period_extractor.md
@@ -1,0 +1,161 @@
+# PeriodExtractor
+
+Computes a multi-band periodogram and derives a best-fit period, per-band periods, a significance estimate (PPE), and optional power-rate features for a light curve.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/period_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `P4J` (v1.2.0), `lc_classifier.utils.is_sorted` (via `numba`)
+
+## Purpose / Meaning
+
+Periodicity is one of the strongest discriminants between variable-star classes (e.g. RR Lyrae, Cepheids, eclipsing binaries) and non-periodic transients. `PeriodExtractor` fits a multi-harmonic Analysis of Variance (MHAOV) periodogram across all available bands simultaneously using `P4J.MultiBandPeriodogram`, returning the best global period and—when the lightcurve is long enough—a set of secondary statistics that measure how clearly the period stands out above the noise.
+
+## Input
+
+### Constructor arguments
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — | Ordered list of band identifiers to process (e.g. `["g", "r"]`). Determines which `fid` values are considered and the `fid` string on multiband features. |
+| `unit` | `str` | — | Photometric unit; must be `"magnitude"` or `"diff_flux"`. Checked at construction; `ValueError` raised otherwise. |
+| `smallest_period` | `float` | — | Lower bound on searched periods (days). Converted to `largest_frequency = 1/smallest_period` inside P4J. |
+| `largest_period` | `float` | — | Upper bound on searched periods (days). Converted to `smallest_frequency = 1/largest_period` inside P4J. |
+| `trim_lightcurve_to_n_days` | `float \| None` | — | If not `None`, the lightcurve is trimmed to the densest contiguous window of this width in days before computing the periodogram. |
+| `min_length` | `int` | — | Minimum number of observations required *per band* for that band to be included; also a global minimum on the total post-filter count. |
+| `use_forced_photo` | `bool` | — | If `True`, `astro_object.forced_photometry` is concatenated with `astro_object.detections` before filtering. |
+| `return_power_rates` | `bool` | — | If `True`, six `Power_rate_*` features are appended. |
+| `shift` | `float` | `0.1` | Controls the coarse frequency-grid density: `grid_size = ceil(f_range * lc_time_length / (2 * shift))`. Smaller values → finer grid → slower computation. |
+
+### `AstroObject` fields read
+
+- `detections` — columns used: `mjd`, `brightness`, `e_brightness`, `fid`, `unit`, `sid`. `sid` is read only for feature-row labelling; `oid` is not required by this extractor.
+- `forced_photometry` — same schema as `detections`; concatenated when `use_forced_photo=True` and the field is not `None`.
+- `metadata` — row with `name == "aid"` is read for error-log messages only; the `aid` value is not used in computation.
+
+### Pre-filtering applied
+
+1. If `use_forced_photo=True` and `forced_photometry` is not `None`, forced-photometry rows are appended to detections.
+2. Rows where `unit != self.unit` are dropped.
+3. Rows where `brightness` is `NaN` are dropped.
+4. Remaining rows are sorted ascending by `mjd`.
+5. `_trim_lightcurve` is applied: a sliding-window O(n) algorithm finds the densest subsequence whose timespan is ≤ `trim_lightcurve_to_n_days` (no-op when `trim_lightcurve_to_n_days is None` or the lightcurve is empty).
+6. For each band in `self.bands`, if the band has fewer than `min_length` observations it is excluded from `useful_bands` and therefore from the periodogram input.
+7. Observations whose `fid` is not in `useful_bands` are dropped.
+8. If the remaining total count is < `min_length`, computation is skipped and all features are emitted as `np.nan`.
+
+### Valid `unit` values
+
+- `"magnitude"` — the extractor mean-subtracts per band inside P4J using a robust weighted median (`robust_loc`); magnitude values are cast to `float32` internally.
+- `"diff_flux"` — treated identically numerically; the difference is only in the physical interpretation of the brightness column.
+
+Both units must have non-negative, finite `e_brightness` values for the MHAOV weighting (`w_i = e_i^{-2}`) to be well-defined.
+
+## Output
+
+Every row appended to `astro_object.features` carries `sid` (joined unique survey IDs from `astro_object.detections["sid"]`, sorted and comma-separated) and `version = "1.0.0"`.
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `Multiband_period` | all bands joined (e.g. `"g,r"`) | Best global period (days): `1 / best_freq[0]` where `best_freq[0]` is the top-ranked frequency after coarse + fine-tune grid search. `np.nan` if computation is skipped. |
+| `PPE` | all bands joined | Period significance (Pseudo-Peak Entropy): `1 - H / log(100)` where H is the Shannon entropy of the top-100 periodogram values (plus a `1e-2` floor) normalised to sum to 1. Range approximately [0, 1]; higher means more significant. `np.nan` if skipped. |
+| `Period_band` | per band (`fid = band`) | Best single-band period (days): `1 / get_best_frequency(band)`, i.e. the coarse-grid index with highest per-band MHAOV power. `np.nan` for any band that did not reach `min_length`. |
+| `delta_period` | per band (`fid = band`) | Absolute difference `|Multiband_period - Period_band|` in days. `np.nan` when either parent is `np.nan`. |
+| `Power_rate_1_4` | all bands joined | Ratio of periodogram power at period `Multiband_period × 0.25` to power at `Multiband_period`. Only present when `return_power_rates=True`. `np.nan` if the periodogram step returned no valid result. |
+| `Power_rate_1_3` | all bands joined | Same ratio at factor `1/3`. |
+| `Power_rate_1_2` | all bands joined | Same ratio at factor `0.5`. |
+| `Power_rate_2` | all bands joined | Same ratio at factor `2.0`. |
+| `Power_rate_3` | all bands joined | Same ratio at factor `3.0`. |
+| `Power_rate_4` | all bands joined | Same ratio at factor `4.0`. |
+
+**Sentinel value:** `np.nan` for all features when the lightcurve is too short or a `TypeError` is raised inside P4J. When `return_power_rates=True` but computation failed, all six `Power_rate_*` features are also `np.nan`.
+
+## Underlying library / math
+
+### `P4J.MultiBandPeriodogram` — coarse grid
+
+- **Function:** `MultiBandPeriodogram.set_data(mjds, mags, errs, fids)`
+- **Algorithm:** For each band `f`, the class constructs a Cython `MHAOV` object (multi-harmonic AoV with `Nharmonics=1`, `mode=0`). Before passing magnitudes to MHAOV, it subtracts a robust per-band location (error-weighted median via `robust_loc`). All arrays are cast to `float32`.
+- **Frequency grid:** `optimal_frequency_grid_evaluation(smallest_period, largest_period, shift)` computes `grid_size = ceil((f_max - f_min) * T / (2 * shift))` where `T` is the lightcurve time span (max − min MJD). `grid_size` is floored at `1_000`. The grid is linearly spaced in frequency between `1/largest_period` and `1/smallest_period`.
+- **Multi-band combination:** `_compute_periodogram` evaluates each band's MHAOV separately, then pools them as:
+
+  ```
+  per_multiband[k] = (d2_sum * per_sum[k]) / (d1 * max(wvar_sum - per_sum[k], 1e-9))
+  ```
+
+  where `d1 = 2 * Nharmonics = 2`, `d2 = N_band - 2*Nharmonics - 1` per band (floored at 0), and `wvar` is the per-band weighted variance. This is an F-statistic formulation of AoV.
+- **Returns:** `self.per` (multiband F-statistic array over the frequency grid) and `self.per_single_band` (dict of per-band arrays).
+
+### `P4J.MultiBandPeriodogram` — fine-tune
+
+- **Function:** `optimal_finetune_best_frequencies(times_finer=10.0, n_local_optima=10)`
+- **Algorithm:** Finds up to 10 local maxima of `self.per` (simple 3-point comparison), then for each one evaluates the periodogram on a finer grid of width = one coarse step, at resolution `freq_step_coarse / 10`. Updates frequencies in place if the finer grid yields a higher power. Stores the top local optima indices in `self.best_local_optima`, sorted descending by power.
+- **`times_finer=10.0` and `n_local_optima=10` are baked in** at the call site in `compute_features_single_object`; they are not constructor arguments.
+
+### `P4J.BasePeriodogram.get_best_frequencies()`
+
+Returns `(self.freq[self.best_local_optima], self.per[self.best_local_optima])` — a pair of arrays of length ≤ `n_local_optima`, sorted by descending multiband power. `best_freq[0]` is the global winner.
+
+### `P4J.BasePeriodogram.get_best_frequency(fid)`
+
+Returns the single frequency index with maximum power in `self.per_single_band[fid]` (argmax over all coarse+fine-tuned frequencies). This is the per-band best frequency, not the multiband one.
+
+### MHAOV algorithm (Cython, compiled)
+
+The `MHAOV` class in `P4J/algorithms/multiharmonic_aov.cpython-310-x86_64-linux-gnu.so` is a Cython extension; no Python source is present in the installed package. Based on the P4J `__init__.py` docstring and the `periodogram` class docstring, MHAOV is described as the *orthogonal multiharmonic AoV periodogram* (reference [7] in the package docstring). For each trial frequency `f`, it fits a truncated Fourier model with `Nharmonics` harmonics to the phased light curve and computes an F-statistic measuring the reduction in weighted variance. With `Nharmonics=1` (the only value used here), this is a 2-parameter sinusoidal fit.
+
+### `lc_classifier.utils.is_sorted`
+
+JIT-compiled via `numba`. Returns `True` if array `a` is non-decreasing. Used in `compute_power_rates` to sort the frequency array before `np.searchsorted` if needed.
+
+## Hardcoded values
+
+| Value | Location | Tunable? | Meaning |
+|-------|----------|----------|---------|
+| `Nharmonics = 1` | `MultiBandPeriodogram.__init__` (P4J library default) | No — not exposed by `PeriodExtractor` | Number of Fourier harmonics in the MHAOV fit. |
+| `mode = 0` | `set_data` in `MultiBandPeriodogram` (P4J) | No | Internal MHAOV mode flag; meaning not documented in available source. |
+| `1e-9` | `_compute_periodogram` denominator clamp (P4J) | No | Numerical floor preventing division by zero in F-statistic. |
+| `times_finer = 10.0` | `compute_features_single_object` call to `optimal_finetune_best_frequencies` | No | Fine-grid is 10× denser than coarse grid around each local optimum. |
+| `n_local_optima = 10` | `compute_features_single_object` call to `optimal_finetune_best_frequencies` | No | Number of local maxima to fine-tune. |
+| `entropy_best_n = 100` | `compute_features_single_object` | No | Number of top periodogram values used to compute PPE entropy. |
+| `1e-2` | Entropy normalization floor | No | Added to each of the 100 top values before normalising, preventing `log(0)`. This shifts PPE values slightly and caps the maximum possible entropy. |
+| `self.factors = [0.25, 1/3, 0.5, 2.0, 3.0, 4.0]` | Constructor | No | Period ratios for `Power_rate_*` features. Correspond to harmonics at ×4, ×3, ×2 and sub-harmonics at ÷2, ÷3, ÷4 of the best period. |
+| `grid_size` floor `1_000` | `optimal_frequency_grid_evaluation` (P4J) | No (controlled indirectly by `shift`) | Minimum number of frequency grid points regardless of lightcurve length. |
+| `shift = 0.1` | Constructor default | Yes — constructor argument | Nyquist-like oversampling factor for the coarse frequency grid. |
+
+## Important considerations
+
+- **Statefulness.** `self.periodogram_computer` is a single `MultiBandPeriodogram` instance shared across all calls to `compute_features_single_object`. It is fully overwritten by `set_data` on each call, so there is no cross-object contamination, but it is **not thread-safe**. Parallel processing of multiple `AstroObject`s with one `PeriodExtractor` instance will cause race conditions.
+
+- **`float32` dtype.** P4J `set_data` casts `mjds`, `mags`, and `errs` to `float32` unconditionally. MJD values for LSST/ZTF (≈ 58000–70000) lose sub-second precision in `float32` (≈ 4 s resolution at those magnitudes). This can affect period resolution for very short periods.
+
+- **`TypeError` swallowing.** Any `TypeError` raised inside `optimal_frequency_grid_evaluation` or `optimal_finetune_best_frequencies` is caught, logged, and results in all-`NaN` output for that object. Other exception types propagate unhandled.
+
+- **Empty `get_best_frequencies` result.** If `best_freq` is empty (checked with `len(best_freq) == 0`), the extractor logs an error and emits `NaN`s. This can occur if `find_local_maxima` finds zero local optima (e.g. monotone periodogram).
+
+- **Per-band vs. multi-band best frequency.** `Multiband_period` uses the global multi-band F-statistic winner. `Period_band` uses the per-band argmax across the full (coarse + fine-tuned) array, which may select a different frequency index because single-band and multi-band power arrays can disagree on the best peak.
+
+- **`Power_rate_*` interpolation.** `_get_power_ratio` uses `np.searchsorted` with nearest-neighbour rounding (not linear interpolation) to find the power at the desired harmonic frequency. When the desired frequency falls exactly at the grid boundary (< `frequencies[0]` → `i=0`, > `frequencies[-1]` → `i=last`), the boundary value is used silently.
+
+- **`delta_period` can be large.** Because `Multiband_period` uses the multi-band argmax and `Period_band` uses the per-band argmax, `delta_period` is not bounded; large values indicate aliasing or incoherent variability across bands.
+
+- **PPE formula.** `PPE = 1 - H / log(entropy_best_n)` where `H` is the entropy of the normalised top-100 periodogram values. The `1e-2` floor on each value means even a perfectly uniform top-100 distribution gives a slightly sub-zero PPE, and a perfect spike gives a value slightly below 1. The scale is not strictly probabilistic.
+
+- **`trim_lightcurve_to_n_days` algorithm.** The sliding-window implementation counts observations (not unique MJDs), so duplicate MJDs from forced photometry are counted separately. The trimmed window is selected by maximum *count*, not maximum time coverage.
+
+- **Feature naming collision.** Both `Period_band` and `delta_period` are emitted once per band with the same `name` column value, distinguished only by `fid`. Downstream consumers must filter by `fid` to disambiguate.
+
+- **`min_length` is applied twice:** once per-band (to decide which bands join `useful_bands`) and once globally after band filtering. A band with fewer than `min_length` observations is excluded, but it still receives `np.nan` entries for `Period_band` and `delta_period`.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `lc_classifier/lc_classifier/features/composites/ztf.py` — `ZTFFeatureExtractor` instantiates `PeriodExtractor` with `unit="magnitude"`, `smallest_period=0.045`, `largest_period=100.0`, `trim_lightcurve_to_n_days=1000.0`, `min_length=15`, `use_forced_photo=True`, `return_power_rates=True`, `shift=0.1`.
+  - `lc_classifier/lc_classifier/features/composites/lsst.py` — same parameters as ZTF.
+  - `lc_classifier/lc_classifier/features/composites/elasticc.py` — `unit` is a constructor argument (not fixed to `"magnitude"`), `largest_period=50.0`, `trim_lightcurve_to_n_days=500.0`, no explicit `shift` (uses default `0.1`).
+
+- **Downstream consumers of `Multiband_period`:**
+  - `lc_classifier/lc_classifier/features/extractors/harmonics_extractor.py` — reads `Multiband_period` from `astro_object.features` to phase-fold the lightcurve for harmonic fitting.
+  - `lc_classifier/lc_classifier/features/extractors/folded_kim_extractor.py` — reads `Multiband_period` to phase-fold and compute Kim et al. morphological features.
+
+- **Tests:** `lc_classifier/tests/features/test_period_feature_extractor.py`.

--- a/lc_classifier/lc_classifier/features/extractors/docs/reference_feature_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/reference_feature_extractor.md
@@ -1,0 +1,96 @@
+# ReferenceFeatureExtractor
+
+Computes statistics describing the proximity and morphology of the photometric reference source associated with each ZTF detection: mean/sigma of source–reference angular separation (`distnr`), and observation-count-weighted mean sharpness (`sharpnr`) and chi-squared (`chinr`) of the reference.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/reference_feature_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** none (only `numpy`, `pandas`)
+
+## Purpose / Meaning
+
+ZTF difference-image photometry subtracts a reference image from each science exposure. The spatial offset between the transient position and the nearest reference source (`distnr`, in arcsec), along with the point-source morphology of that reference (`sharpnr`, `chinr`), are diagnostics that help distinguish nuclear transients from off-nucleus events and artefacts. A training-set constraint (the ZTF forced-photometry service used a 5 arcsec cone) is baked into the pre-filtering step.
+
+## Input
+
+### Constructor arguments
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — (required) | Band identifiers used to filter observations and form the `fid` label of every emitted feature (e.g. `["g", "r"]`). |
+
+The class-level constant `unit = "diff_flux"` is not a constructor argument; it cannot be overridden at instantiation without subclassing.
+
+### `AstroObject` fields read
+
+- `detections` — mandatory. Columns read: `unit`, `brightness`, `e_brightness`, `fid`, `distnr`, `rfid`.
+- `forced_photometry` — optional (`None` is handled). When present, concatenated with `detections` before filtering. Same columns as above must be present.
+- `reference` — optional (`None` is handled). Expected columns: `rfid` (integer reference-image ID), `sharpnr` (PSF sharpness of the reference source), `chinr` (chi-squared of the PSF fit of the reference source).
+- `features` — existing feature rows; the extractor appends to them in place.
+
+`detections` must contain `sid` (used only to populate the output `sid` column); the mandatory columns enforced by `AstroObject.__post_init__` are `oid`, `sid`, `fid`.
+
+### Pre-filtering applied
+
+1. Merge `detections` and `forced_photometry` (if not `None`) via `pd.concat`.
+2. Keep rows where `unit == "diff_flux"`.
+3. Keep rows where `brightness` is not `NaN`.
+4. Keep rows where `e_brightness > 0.0`.
+5. Keep rows where `fid` is in `self.bands`.
+6. Keep rows where `0.0 <= distnr <= 5.0` and `distnr` is not `NaN` — **hardcoded 5 arcsec upper bound** (see *Hardcoded values*).
+
+After the `distnr` statistics are computed, an additional filter is applied for the `sharpnr`/`chinr` path: rows where `rfid` is `NaN` are dropped and `rfid` is cast to `int`.
+
+### Valid `unit` values
+
+Only `"diff_flux"` passes the unit filter. Observations with any other unit (e.g. `"magnitude"`) are silently discarded before any computation.
+
+## Output
+
+All four features share the same `fid` value: `",".join(self.bands)` (e.g. `"g,r"` for ZTF). The `sid` value is `",".join(sorted(astro_object.detections["sid"].unique()))`.
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `mean_distnr` | all bands joined | Arithmetic mean of `distnr` over all post-filter observations (arcsec). |
+| `sigma_distnr` | all bands joined | Standard deviation (`pandas` default: ddof=1) of `distnr` over all post-filter observations. `NaN` if fewer than 2 observations pass the filter (pandas behaviour). |
+| `mean_sharpnr` | all bands joined | Observation-count-weighted mean of `sharpnr` across reference images. |
+| `mean_chinr` | all bands joined | Observation-count-weighted mean of `chinr` across reference images. |
+
+**Sentinel value:** `np.nan`. Emitted for `mean_distnr` and `sigma_distnr` when no observations survive pre-filtering. Emitted for `mean_sharpnr` and `mean_chinr` when: (a) no observations with a valid `rfid` exist after filtering, (b) `astro_object.reference` is `None` or an empty `DataFrame`, or (c) no observations match any `rfid` in the reference table (`n_obs_with_ref == 0`).
+
+The four feature rows are always appended regardless of whether they are `NaN`; the extractor never short-circuits before building the output `DataFrame`.
+
+Downstream schemas rename these features by appending the band suffix, e.g. `mean_distnr` with `fid="g,r"` → `mean_distnr_12` in the ZTF Avro schema (see *Cross-references*).
+
+## Underlying library / math
+
+No third-party scientific libraries are called. All computation uses standard `pandas` and `numpy`:
+
+- `observations["distnr"].mean()` — arithmetic mean (ignores NaN by default).
+- `observations["distnr"].std()` — sample standard deviation with `ddof=1` (pandas default).
+- Weighted mean of `sharpnr`/`chinr`: explicit Python loop over reference rows, accumulating `sharpnr_row * n_obs_for_that_rfid`; divides by total matched observation count. Equivalent to weighting each reference's morphology statistics by how many observations in the current object used that reference image.
+
+## Hardcoded values
+
+| Value | Location | Tunable? | Meaning |
+|-------|----------|----------|---------|
+| `"diff_flux"` | class attribute `unit` | No (without subclassing) | Only `diff_flux` observations are processed. |
+| `0.0` (lower bound on `distnr`) | `get_observations`, line 30 | No | Rejects nonsensical negative distances (likely flagged/bad values). |
+| `5.0` (upper bound on `distnr`) | `get_observations`, line 31 | No | 5 arcsec cone match — derived from the ZTF forced-photometry training service limit. Comment in source: *"5 arcsec limit is because of training set limitations (it used the ZTF forced photometry service)"*. |
+
+## Important considerations
+
+- **`sigma_distnr` is `NaN` for single-observation objects.** `pandas.Series.std()` with `ddof=1` returns `NaN` when the series has length 1.
+- **`astro_object.reference` is expected to have one row per reference image, not one row per observation.** The loop iterates over reference rows and uses `rfid` to count how many observations map to each reference. If `reference` contains duplicate `rfid` values the weighted average double-counts those entries.
+- **`rfid` cast to `int` before join.** If `rfid` in `observations` contains float representations of integers (e.g. `1.0`), the cast succeeds. If it contains non-integer floats the cast raises `ValueError` and the extractor will propagate the exception rather than returning NaNs — there is no exception guard in this path.
+- **In-place mutation.** `compute_features_single_object` appends to `astro_object.features` directly. Calling the extractor twice on the same object will duplicate all four feature rows.
+- **`distnr` sourced from merged detections + forced photometry.** The `distnr` statistics therefore reflect both detection and forced-photometry epochs when `forced_photometry` is provided.
+- **`sid` is taken from `detections` only**, not from the merged observations DataFrame. Forced-photometry rows may carry different `sid` values that are not reflected in the output `sid` column.
+- **No `min_length` guard.** Unlike many other extractors in this codebase, `ReferenceFeatureExtractor` does not enforce a minimum number of observations; it returns computed values (or NaNs) regardless of how few observations survive filtering.
+- **ZTF-specific columns.** `distnr`, `rfid`, `sharpnr`, and `chinr` are ZTF-pipeline columns. This extractor is not meaningful for surveys that do not populate these fields.
+
+## Cross-references
+
+- **Composite that includes this extractor:** `ZTFFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/ztf.py`, line 63). It is instantiated as `ReferenceFeatureExtractor(bands)` with `bands = list("gr")`.
+- **Downstream schema consumers:** `lc_classification_step/tests/mockdata/features_ztf.py`, `lc_anomaly_step/tests/mockdata/features_ztf.py`, and `alerce_classifiers/tests/mockdata/schemas.py` all expect the renamed forms `mean_chinr_12`, `mean_distnr_12`, `mean_sharpnr_12`, `sigma_distnr_12`. The rename from `fid="g,r"` to the `_12` suffix happens in the training/ingestion utilities (`training/lc_classifier_ztf/ATAT_ALeRCE/data/utils.py`, lines 161–164).
+- **Other extractors reading the same `AstroObject` fields:** No other extractor in the ZTF composite reads `astro_object.reference`. `detections` and `forced_photometry` are consumed by most other extractors in `ZTFFeatureExtractor`.

--- a/lc_classifier/lc_classifier/features/extractors/docs/sn_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/sn_extractor.md
@@ -1,0 +1,127 @@
+# SNExtractor
+
+Computes supernova-oriented flux features per photometric band, characterising the brightness level before, at, and after the first detection using forced-photometry baselines.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/sn_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor` (abstract, from `lc_classifier.features.core.base`)
+- **External libs:** `numpy`, `pandas` (no third-party scientific library)
+
+## Purpose / Meaning
+
+Supernovae and similar transient events exhibit a characteristic rise in differential flux starting from a quiescent pre-explosion baseline. This extractor quantifies the pre- and post-detection forced-photometry context — how many baseline epochs exist, the brightness jump at first detection, and the extreme/central flux values surrounding the event — to give classifiers a direct view of transient onset and evolution.
+
+## Input
+
+### Constructor arguments
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — (required) | Photometric band identifiers to iterate over (e.g. `["g","r"]`, `list("ugrizY")`). |
+| `unit` | `str` | — (required) | Physical unit of the `brightness` column. Must be `"diff_flux"`; any other value raises `ValueError` at construction time. |
+| `use_forced_photo` | `bool` | — (required) | Whether to use `astro_object.forced_photometry`. If `False`, all forced-photometry features are emitted as `np.nan`. |
+
+### `AstroObject` fields read
+
+- `detections` — columns used: `mjd`, `brightness`, `fid`, `unit`, `sid`.
+- `forced_photometry` — columns used: `mjd`, `brightness`, `fid`, `unit`. Read only when `use_forced_photo=True` and the field is not `None`.
+
+### Pre-filtering applied
+
+1. `detections` is filtered to rows where `unit == self.unit`.
+2. `detections` is sorted ascending by `mjd` before the first-detection timestamp and first brightness are extracted.
+3. Per band, `detections_band` is re-sorted by `mjd` before reading `iloc[0]`.
+4. `forced_photometry` is filtered to `unit == self.unit`, then to the current band (`fid == band`), then split at `first_detection_mjd` into before/after sub-tables, each sorted by `mjd`.
+5. No global `min_length` trim beyond `detections_min_len = 1` for `positive_fraction`.
+
+### Valid `unit` values
+
+Only `"diff_flux"` is accepted; the constructor raises `ValueError` for anything else. Downstream, `brightness` values from `detections` and `forced_photometry` are treated as signed flux differences (positive = brightening above template).
+
+## Output
+
+Every row appended to `astro_object.features` has columns `name`, `value`, `fid`, `sid`, `version`.
+
+`sid` is derived from the unique `sid` values present in the (unit-filtered) detections, sorted alphabetically and joined with a comma. `version` is `"1.0.0"`.
+
+For each band in `self.bands`, the following ten features are appended:
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `positive_fraction` | per band | Fraction of in-band detections with `brightness > 0` (i.e. above the difference-image template). |
+| `n_forced_phot_band_before` | per band | Number of forced-photometry epochs **before** `first_detection_mjd` in this band. |
+| `dbrightness_first_det_band` | per band | `brightness(first_detection_in_band) - last_forced_phot_brightness_before`. Brightness step at onset. |
+| `dbrightness_forced_phot_band` | per band | `brightness(first_detection_in_band) - median(forced_phot_before_in_band)`. Brightness jump relative to median baseline. |
+| `last_brightness_before_band` | per band | Brightness of the chronologically last forced-photometry epoch before first detection. |
+| `max_brightness_before_band` | per band | Maximum brightness among all pre-detection forced-photometry epochs. |
+| `median_brightness_before_band` | per band | Median brightness among all pre-detection forced-photometry epochs. |
+| `n_forced_phot_band_after` | per band | Number of forced-photometry epochs **after** `first_detection_mjd` in this band. |
+| `max_brightness_after_band` | per band | Maximum brightness among all post-detection forced-photometry epochs. |
+| `median_brightness_after_band` | per band | Median brightness among all post-detection forced-photometry epochs. |
+
+**Sentinel value:** `np.nan`. The exact conditions that produce `np.nan` for each feature are listed under *Important considerations*.
+
+## Underlying library / math
+
+No third-party scientific library is invoked. All arithmetic is native `numpy`:
+
+- `np.mean(array > 0)` — fraction of positive elements.
+- `np.median(array)` — median brightness.
+- `np.max(array)` — maximum brightness.
+- Subtraction for delta-brightness features.
+
+`pandas` is used only for filtering, sorting, and `DataFrame` construction.
+
+## Hardcoded values
+
+| Literal | Location | Tunable? | Meaning |
+|---------|----------|----------|---------|
+| `self.detections_min_len = 1` | `__init__` | No | Minimum number of in-band detections required before `positive_fraction` is computed instead of emitting `np.nan`. |
+| `valid_units = ["diff_flux"]` | `__init__` | No | The sole permitted unit; raises `ValueError` at construction for any other string. |
+| `"1.0.0"` | `self.version` | No | Written to every emitted feature row. |
+
+No windowing, period, frequency, or threshold constants are present.
+
+## Important considerations
+
+**When `np.nan` is emitted:**
+
+- `positive_fraction`: emitted as `np.nan` if the band has fewer than `detections_min_len` (= 1) detections after unit filtering.
+- All nine remaining features: emitted as `np.nan` when `use_forced_photo=False` or `forced_photometry is None` or `len(forced_photometry_band) == 0`.
+- `n_forced_phot_band_before`, `last_brightness_before_band`, `dbrightness_first_det_band`, `dbrightness_forced_phot_band`, `max_brightness_before_band`, `median_brightness_before_band`: emitted as `np.nan` (except `n_forced_phot_band_before`, which is set to `0`) when no forced-photometry epochs precede `first_detection_mjd` in the band.
+- `max_brightness_after_band`, `median_brightness_after_band`: emitted as `np.nan` when `n_forced_phot_band_after == 0`.
+- `first_detection_mjd`: set to `np.nan` when `detections` is empty after unit filtering; in that case all temporal splits of forced photometry will yield empty sub-tables (since `mjd < np.nan` and `mjd > np.nan` are always `False`), so most features will be `np.nan`.
+
+**`dbrightness_first_det_band` vs `dbrightness_forced_phot_band`:**
+Both measure a brightness rise at onset, but against different references: `dbrightness_first_det_band` uses the immediately preceding forced-photometry point (chronological last before detection), while `dbrightness_forced_phot_band` uses the median of the entire pre-detection baseline. The two will differ when the baseline is not flat.
+
+**`first_detection_mjd` is global across bands:**
+The split between "before" and "after" forced photometry is always relative to the first detection across all bands combined, not the first detection within the current band. A band with an earlier first detection than other bands may therefore have no "before" epochs at all.
+
+**Forced photometry is re-filtered inside the band loop:**
+The `forced_photometry` variable is re-assigned to the unit-filtered slice on every iteration of the band loop (line 59: `forced_photometry = forced_photometry[forced_photometry["unit"] == self.unit]`). This is safe because pandas slice assignment creates a new object, but it means the filter is applied redundantly on every band after the first.
+
+**`sid` field encoding:**
+All unique `sid` values from the unit-filtered `detections` are sorted and joined into a single comma-separated string (e.g. `"LSST,ZTF"`). Every feature row for the object carries this same string.
+
+**In-place mutation:**
+`compute_features_single_object` mutates `astro_object.features` in place via `pd.concat`, consistent with the `FeatureExtractor` contract (`"""This method is inplace"""`).
+
+**No exception handling:**
+The extractor does not catch any exceptions internally. A `KeyError` (missing column), `TypeError`, or `IndexError` in the input DataFrames will propagate to the caller.
+
+## Cross-references
+
+**Composites that include this extractor:**
+
+- `lc_classifier/lc_classifier/features/composites/ztf.py` — instantiated as `SNExtractor(bands, unit="diff_flux", use_forced_photo=True)` with `bands = ["g", "r"]`.
+- `lc_classifier/lc_classifier/features/composites/lsst.py` — instantiated as `SNExtractor(bands, unit="diff_flux", use_forced_photo=True)` with `bands = ["u","g","r","i","z","y"]`.
+- `lc_classifier/lc_classifier/features/composites/elasticc.py` — instantiated as `SNExtractor(bands, unit, use_forced_photo=True)` with `bands = list("ugrizY")` and `unit = "diff_flux"`.
+
+**Tests:**
+
+- `lc_classifier/tests/features/test_sn_extractor.py` — exercises with an ELAsTiCC example object and asserts that `unit="magnitude"` raises `ValueError`.
+
+**Other extractors sharing the same `AstroObject` fields:**
+
+- Any extractor that reads `detections["brightness"]` or `forced_photometry` in `diff_flux` units (e.g. `MHPSExtractor`, `GPDRWExtractor`, `SNParametricModelExtractor`) operates on the same underlying data; no output features from `SNExtractor` are consumed as inputs by other extractors in this repository.

--- a/lc_classifier/lc_classifier/features/extractors/docs/spm_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/spm_extractor.md
@@ -1,0 +1,247 @@
+# SPMExtractor
+
+Fits a six-parameter Supernova Parametric Model (SPM) to a multi-band differential-flux light curve using JAX-JIT-compiled objective with analytic gradients supplied to `scipy.optimize.minimize` (TNC), and optionally corrects for Milky Way extinction and cosmological distance before fitting.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/spm_extractor.py`
+- **Version:** `1.0.1`
+- **Base class:** `FeatureExtractor` (abstract, from `lc_classifier.features.core.base`)
+- **External libs:** `jax`, `numba`, `scipy.optimize`, `extinction` (v0.4.7), `astropy.cosmology.WMAP5`
+
+## Purpose / Meaning
+
+The SPM is a physically-motivated analytic model for supernova-like transient light curves. Fitting it per band yields interpretable shape parameters (amplitude, rise time, fall time, plateau length, plateau slope, time of onset) that serve as compact descriptors for transient classification. The reduced chi-squared of the fit provides a quality-of-fit metric. Together the parameters form a compact representation of the light curve morphology that is robust to irregular cadence and missing bands.
+
+## Input
+
+### Constructor arguments
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — (required) | Photometric band identifiers. Each must be in `{"u","g","r","i","z","y"}`; otherwise `ValueError` is raised. |
+| `unit` | `str` | — (required) | Physical unit of `brightness`. Only `"diff_flux"` is accepted; anything else raises `ValueError`. |
+| `redshift` | `Optional[str]` | `None` | Name of the `metadata` field holding the host-galaxy redshift. If `None`, no redshift correction is applied. |
+| `extinction_color_excess` | `Optional[str]` | `None` | Name of the `metadata` field holding the Milky Way color excess `E(B-V)`. If `None`, no dust correction is applied. |
+| `forced_phot_prelude` | `Optional[float]` | `None` | Number of days before the first detection to keep forced-photometry epochs. Epochs earlier than `first_detection_mjd - forced_phot_prelude` are discarded. If `None`, all pre-detection forced photometry is retained. |
+
+### `AstroObject` fields read
+
+- `detections` — columns: `mjd`, `brightness`, `e_brightness`, `fid`, `unit`, `sid`.
+- `forced_photometry` — columns: `mjd`, `brightness`, `e_brightness`, `fid`, `unit`. Appended to detections when `astro_object.forced_photometry is not None`.
+- `metadata` — queried for the redshift value (by `metadata["name"] == self.redshift_name`) and for `E(B-V)` (by `metadata["name"] == self.extinction_color_excess_name`) when the respective constructor arguments are not `None`.
+
+### Pre-filtering applied
+
+1. `detections` is copied; `astro_object.forced_photometry` is concatenated when present.
+2. Rows where `unit != self.unit` are dropped.
+3. Rows where `brightness` is `NaN` are dropped.
+4. If `forced_phot_prelude` is set, rows with `mjd <= first_detection_mjd - forced_phot_prelude` are dropped.
+5. `mjd` is shifted so that `min(mjd) == 0` (i.e. time is relative to the first surviving epoch).
+6. All `brightness` and `e_brightness` values are multiplied by `0.001` (mJy → milli-unit conversion note; see *Hardcoded values*).
+7. If `mwebv` (extinction) and `zhost` (redshift) are available, per-band flux and error are multiplied by a combined de-attenuation factor before fitting (see *Underlying library / math*).
+
+### Valid `unit` values
+
+Only `"diff_flux"` is accepted. The constructor enforces this at construction time. Downstream code assumes `brightness` values are signed differential fluxes.
+
+## Output
+
+Every row appended to `astro_object.features` has columns `name`, `value`, `fid`, `sid`, `version`.
+
+`sid` is derived from the unique `sid` values present in `astro_object.detections` (before any filtering), sorted and joined with a comma. `version` is `"1.0.1"`.
+
+For each band in `self.bands`, seven features are appended:
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `SPM_A` | per band | Amplitude parameter of the SPM model (in the scaled flux unit after the `× 0.001` rescaling). |
+| `SPM_t0` | per band | Onset time (days relative to first surviving epoch). The model rises steeply after this time. |
+| `SPM_gamma` | per band | Plateau duration in days. The transition between linear plateau and exponential decay occurs at `t1 = t0 + gamma`. |
+| `SPM_beta` | per band | Plateau slope parameter in `[0, 1]`. `beta=0` means flat plateau; `beta=1` means maximum linear decline during the plateau phase. |
+| `SPM_tau_rise` | per band | Characteristic rise timescale in days. Controls how rapidly flux increases from zero to peak near `t0`. |
+| `SPM_tau_fall` | per band | Characteristic fall timescale in days. Controls the exponential decay rate after the plateau ends. |
+| `SPM_chi` | per band | Reduced chi-squared of the best-fit model on the band's detection epochs: `sum((model - flux)^2 / (error + 1e-3)^2) / (N - 6)`. |
+
+**Sentinel value:** `np.nan`. Conditions that produce `np.nan`:
+
+- The observations DataFrame is empty after all filtering: all six SPM parameters and `SPM_chi` are `np.nan` for every band.
+- A band in `self.bands` has no observations (i.e. is not in `available_bands` from the data): all six SPM parameters and `SPM_chi` are `np.nan` for that band.
+- A band has 6 or fewer observations (`N - 6 < 1`): `SPM_chi` is `np.nan` for that band (denominator of chi-squared would be non-positive).
+
+## Underlying library / math
+
+### SPM model formula
+
+The model flux at time `t` for a band with parameters `(A, t0, gamma, beta, tau_rise, tau_fall)` is:
+
+```
+t1 = t0 + gamma
+
+rise_factor(t)  = sigmoid((t - t0) / tau_rise)        # 1 / (1 + exp(-(t-t0)/tau_rise))
+trans_factor(t) = sigmoid(0.5 * (t - t1))             # transition at t1
+
+plateau(t) = 1 - beta * (t - t0) / gamma              # linearly declining plateau
+decay(t)   = (1 - beta) * exp(-(t - t1) / tau_fall)   # exponential decay after t1
+
+model(t) = A * rise_factor(t) * [decay(t) * trans_factor(t) + plateau(t) * (1 - trans_factor(t))]
+```
+
+`trans_factor` smoothly blends between the plateau phase (for `t < t1`) and the exponential decay phase (for `t > t1`). `rise_factor` suppresses flux before `t0`.
+
+When `tau_fall < tau_rise` the model can diverge for early times; the code forces `trans_factor = 0` for `t < t1` in that case.
+
+Numerical clipping is applied throughout to prevent overflow:
+- `sigmoid_exp_arg` for the transition is clipped to `[-10, 10]`.
+- `fall_exp_arg` is clipped to `[-20, 20]`.
+- `den_exp_arg` for the rise denominator is clipped; values `< -20` map to zero output.
+
+### Objective function — JAX + `grad`
+
+**Function:** `objective_function_jax` (module-level, decorated with `@jax_jit`)
+
+The objective is the sum of weighted squared residuals across all bands, plus a regularization term:
+
+```
+loss = sum_over_bands( dot(band_sqerr, ignore_negative_fluxes) ) + regularization
+```
+
+where:
+- `band_sqerr[i] = ((model(t_i) - flux_i) / (error_i + smooth_error))^2`
+- `ignore_negative_fluxes[i] = exp( -((flux_i + error_i) / (error_i + 1e-3))^2 )` when `flux_i + error_i < 0`, else `1.0`. This soft-downweights epochs where both flux and error are negative (likely bogus detections).
+- `smooth_error = 0.5 * percentile(obs_errors, 10)` — adds a floor to the per-point error, preventing over-fitting to very small errors.
+
+**Regularization:**
+
+```
+params_var = [var(A) + 1, var(t0) + 0.05, var(gamma) + 0.05, var(beta) + 0.005, var(tau_rise) + 0.05, var(tau_fall) + 0.05]
+lambdas    = [0.0, 1.0, 0.1, 20.0, 0.7, 0.01]   # per-parameter weights
+regularization = dot(lambdas, sqrt(params_var))
+```
+
+Regularization couples multi-band fits: the variance in each parameter across bands is penalized, pushing solutions toward shared shape across bands. `beta` is penalized most strongly (`lambda=20`). `A` (amplitude) is not regularized (`lambda=0`), because amplitudes are expected to differ between bands.
+
+**Analytic gradient:** `grad_objective_function_jax = jax_jit(grad(objective_function_jax))` — JAX auto-diff, JIT-compiled. This exact function is passed as `jac=` to `scipy.optimize.minimize`.
+
+**Note:** JAX is configured with `jax.config.update("jax_enable_x64", True)` at module import time (module-level side effect), enabling 64-bit float throughout.
+
+### Optimizer — `scipy.optimize.minimize` (TNC)
+
+**Function:** `scipy.optimize.minimize(..., method="TNC", bounds=bounds, options={"maxfun": 1000})`
+
+- **Algorithm:** Truncated Newton Conjugate-gradient (TNC) — a bound-constrained quasi-Newton method. Uses the analytic gradient. Handles per-parameter box bounds.
+- **`maxfun`:** Maximum 1000 function evaluations per fit (baked in; not tunable via constructor).
+- **Bounds:** Per-band parameter bounds are computed from data; shared `t0` bounds are `[-50, max(times)]`.
+
+### Model inference for chi-squared — `model_inference_stable` (Numba)
+
+**Function:** `model_inference_stable(times, A, t0, gamma, beta, t_rise, t_fall)` decorated with `@jit(nopython=True)`.
+
+Implements the same SPM formula as the JAX objective but using `numpy` arithmetic and explicit clipping. Used only for computing chi-squared after the optimization, not during fitting. `numba.set_num_threads(1)` is set in `SNModel.__init__` to avoid thread contention.
+
+### Extinction correction — `extinction.odonnell94`
+
+**Function:** `extinction.odonnell94(wavelengths, av, rv)` — compiled C extension (`extinction` v0.4.7).
+
+- **Algorithm:** O'Donnell (1994) parameterization of the interstellar extinction curve. Returns extinction in magnitudes at each input wavelength.
+- **`rv`:** Hardcoded to `3.1` (standard diffuse ISM value).
+- **`av`:** Computed as `rv * mwebv` where `mwebv = E(B-V)` from metadata.
+- **Usage:** `extinction.odonnell94(np.array([cws[band]]), av, rv)[0]` — single wavelength per call, in Angstroms.
+- **De-attenuation factor:** `10 ** (A_lambda / 2.5)` — converts from magnitudes of extinction to a linear flux multiplier.
+
+**Central wavelengths (`self.cws`) used as inputs to `odonnell94`:**
+
+| Band | Wavelength (Angstrom) |
+|------|----------------------|
+| `u`  | 3671.0 |
+| `g`  | 4827.0 |
+| `r`  | 6223.0 |
+| `i`  | 7546.0 |
+| `z`  | 8691.0 |
+| `y`  | 9712.0 |
+
+These are baked into `self.cws` and are not tunable.
+
+### Cosmological distance correction — `astropy.cosmology.WMAP5.distmod`
+
+**Function:** `WMAP5.distmod(z)` — returns the distance modulus `mu(z)` in magnitudes.
+
+- **WMAP5 parameters (from `astropy/cosmology/data/WMAP5.ecsv`):** `H0=70.2 km/s/Mpc`, `Om0=0.277`, `Tcmb0=2.725 K`, `Neff=3.04`, flat ΛCDM. Reference: Komatsu et al. 2009, ApJS 180, 330.
+- **Correction applied:** A redshift de-attenuation factor `zdeatt = 10^(-(distmod(0.3) - distmod(zhost)) / 2.5)` is combined multiplicatively with the dust correction. The factor maps observed flux to the flux the source would have at the reference redshift `z=0.3`.
+- **Reference redshift `0.3`:** Hardcoded; not tunable via constructor.
+- **Threshold:** If `zhost < 0.003` or `zhost is None`, `zdeatt = 1.0` (no correction). The threshold `0.003` is hardcoded.
+
+**Note:** The time-axis redshift correction `times /= (1 + zhost)` is present in the source but commented out. Time dilation is therefore not applied.
+
+## Hardcoded values
+
+| Literal | Location | Tunable? | Meaning |
+|---------|----------|----------|---------|
+| `0.001` | `get_observations` | No | Multiplies all `brightness` and `e_brightness` values. The comment reads "old SPM used milli Jansky, not uJy", indicating this converts from µJy (current pipeline unit) to mJy for backwards compatibility with the model's implicit scale. |
+| `self.cws` (6 wavelengths) | `__init__` | No | Effective central wavelengths per band for extinction computation (Angstroms). |
+| `rv = 3.1` | `_deattenuation_factor` | No | Standard ratio of total-to-selective extinction for diffuse ISM. |
+| `zhost_threshold = 0.003` | `_correct_lightcurve` | No | Minimum redshift below which the cosmological correction is skipped. |
+| `reference_z = 0.3` | `_correct_lightcurve` | No | Pivot redshift for the distance-modulus amplitude correction. |
+| `pad_multiple = 250` | `pad()` | No | Input arrays are padded to the next multiple of 250 before being passed to the JAX function. Required for JAX JIT to avoid recompiling for every distinct array length. |
+| `t0_bounds = [-50.0, max(times)]` | `SNModel.fit` | No | Lower bound on `t0`: onset may be up to 50 days before the first observation. |
+| `gamma_guess = 14.0` | `SNModel.fit` | No | Initial guess for plateau duration (days). |
+| `beta_guess = 0.5` | `SNModel.fit` | No | Initial guess for plateau slope. |
+| `trise_guess = 7.0` | `SNModel.fit` | No | Initial guess for rise timescale (days). |
+| `tfall_guess = 28.0` | `SNModel.fit` | No | Initial guess for fall timescale (days). |
+| `t0_guess_offset = -10.0` | `SNModel.fit` | No | `t0` initial guess is `argmax_flux_time - 10` days. |
+| `A_guess_factor = 1.2` | `SNModel.fit` | No | `A` initial guess is `1.2 * max_flux_in_band`. |
+| `A_bounds = [|max_flux|/10, |max_flux|*10]` | `SNModel.fit` | No | Amplitude bounds are data-driven but anchored to the observed maximum. |
+| `gamma_bounds = [1.0, 120.0]` | `SNModel.fit` | No | Plateau duration allowed range (days). |
+| `beta_bounds = [0.0, 1.0]` | `SNModel.fit` | No | Plateau slope bounded to unit interval. |
+| `trise_bounds = [1.0, 100.0]` | `SNModel.fit` | No | Rise timescale allowed range (days). |
+| `tfall_bounds = [1.0, 180.0]` | `SNModel.fit` | No | Fall timescale allowed range (days). |
+| `smooth_error = 0.5 * percentile(obs_errors, 10)` | `SNModel.fit` | No | Error floor added to each point's uncertainty in the objective. |
+| `ignore_negative threshold` | `SNModel.fit` | No | Negative observations: weight `exp(-((flux+err)/(err+1e-3))^2)` when `flux + err < 0`. |
+| `maxfun = 1000` | `SNModel.fit` | No | Maximum TNC function evaluations. |
+| `sigmoid_factor = 0.5` | `objective_function_jax` | No | Steepness of the plateau-to-decay transition sigmoid. |
+| `lambda_regularization` | `objective_function_jax` | No | Per-parameter regularization weights: `[0.0, 1.0, 0.1, 20.0, 0.7, 0.01]` for `[A, t0, gamma, beta, tau_rise, tau_fall]`. |
+| `prefered_order = "irzygu"` | `SNModel.fit` | No | Band priority for selecting the best available band for `t0` initial guess (redder bands preferred). |
+| `band_mapper = dict(zip("grizyu", range(1,7)))` | `SNModel.fit` | No | Maps band characters to integer IDs for use inside the JAX JIT function. |
+| `chi_den_floor = 1` | `SNModel.fit` | No | `SPM_chi` is `np.nan` when `N_obs - 6 < 1`. |
+| `1e-3` | `SNModel.fit` (chi computation) | No | Error floor added to `band_errors` in the chi-squared denominator: `(error + 1e-3)^2`. |
+
+## Important considerations
+
+**Unit rescaling trap:** All fluxes are multiplied by `0.001` inside `get_observations`. The SPM parameters `SPM_A` and the chi-squared are therefore expressed in the rescaled unit (mJy if the pipeline delivers µJy). Consumers must be aware of this when interpreting `SPM_A` in physical units.
+
+**JAX module-level side effect:** `jax.config.update("jax_enable_x64", True)` is executed at import time. This affects all JAX computations in the same Python process, not just those in this extractor. Importing `spm_extractor` may silently change the default dtype behaviour of unrelated JAX code.
+
+**JAX JIT recompilation:** The `objective_function_jax` and `grad_objective_function_jax` are `@jax_jit` compiled. JAX traces on the first call and recompiles whenever the input shapes change. Input arrays are padded to the next multiple of 250 to limit the number of distinct shapes seen by JAX (reducing recompilation). The class docstring notes: `"the firsts calls are really expensive because of jax compilations"`.
+
+**Multi-band coupling via regularization:** The optimization is global across all available bands simultaneously. Per-band parameters are regularized against each other through the cross-band variance terms in the objective. Fitting a single-band light curve still works (variance across bands is zero), but the `+ offset` terms in `params_var` ensure regularization is never zero.
+
+**`SNModel` is stateful and reused:** A single `SNModel` instance is created in `SPMExtractor.__init__` and reused across all calls to `compute_features_single_object`. `self.parameters` and `self.chis` are overwritten on each call. This is not thread-safe.
+
+**`numba.set_num_threads(1)`:** Set once in `SNModel.__init__`. This is a process-wide Numba setting that persists after the call and may affect other Numba-compiled functions in the same process.
+
+**Band availability:** The optimizer only runs on `available_bands` (bands that actually appear in the filtered observations). Bands listed in `self.bands` but absent from the data receive `np.nan` for all seven features. The band ordering for `available_bands` (and thus for the parameter block layout in `res.x`) is determined by `np.unique`, which returns bands in sorted lexicographic order.
+
+**`t0` is shared across bands:** Only one `t0_bounds` and `t0_guess` is computed (from the preferred reference band), but each band in `available_bands` gets its own independent `t0` parameter in the optimization. The shared initial guess and bounds are used for all bands.
+
+**Optimizer may not converge:** `res.success` is extracted from the TNC result but is never checked; the best-available `res.x` is used regardless of convergence status. There is no fallback or warning when `success == False`.
+
+**No exception handling in `compute_features_single_object`:** Errors during metadata lookup (e.g., the redshift or `mwebv` key not present in `metadata`), optimizer errors, or Numba errors will propagate to the caller without being caught.
+
+**`_correct_lightcurve` mutates arrays in place:** The `flux` and `e_flux` arrays extracted from the observations DataFrame are modified by multiplying the de-attenuation factor. These are `.values` numpy arrays, so the mutation does not affect the source DataFrame.
+
+**Cosmological correction reference redshift `0.3`:** The correction normalizes flux to the distance modulus difference `distmod(0.3) - distmod(zhost)`. This means at `zhost=0.3` the factor is `1.0`, and at higher (lower) redshifts flux is boosted (reduced) to match the `z=0.3` scale. This is an unusual choice that will produce systematically different `SPM_A` values for objects at different redshifts. The choice is baked in and not documented in source comments.
+
+**`extinction` is a compiled C extension:** `extinction.odonnell94` is implemented in Cython/C (`extinction.cpython-310-x86_64-linux-gnu.so`). No readable Python source is available in the installed package. The function signature inferred from usage: `odonnell94(wave: np.ndarray[float64], a_v: float, r_v: float) -> np.ndarray[float64]` returning extinction in magnitudes.
+
+## Cross-references
+
+**Composites that include this extractor:**
+
+- `lc_classifier/lc_classifier/features/composites/ztf.py` — instantiated as `SPMExtractor(["g","r"], unit="diff_flux", redshift=None, extinction_color_excess=None, forced_phot_prelude=30.0)`.
+- `lc_classifier/lc_classifier/features/composites/lsst.py` — instantiated as `SPMExtractor(["u","g","r","i","z","y"], unit="diff_flux", redshift=None, extinction_color_excess=None, forced_phot_prelude=30.0)`.
+- `lc_classifier/lc_classifier/features/composites/elasticc.py` — instantiated as `SPMExtractor(list("ugrizY"), unit="diff_flux", redshift="REDSHIFT_HELIO", extinction_color_excess="MWEBV", forced_phot_prelude=30.0)`. This is the only composite that activates both extinction and redshift corrections.
+
+**Other extractors that share the same `AstroObject` fields:**
+
+- `SNExtractor` (`sn_extractor.py`) — also reads `detections` and `forced_photometry` in `diff_flux`; operates on the same flux columns.
+- `MHPSExtractor`, `GPDRWExtractor` — also consume `diff_flux` brightness from `detections`/`forced_photometry`.
+
+**No downstream extractor in this repository reads SPM output feature names** as input to further computation; the features are consumed directly by downstream classifiers.

--- a/lc_classifier/lc_classifier/features/extractors/docs/tde_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/tde_extractor.md
@@ -1,0 +1,232 @@
+# TDETailExtractor / FleetExtractor / ColorVariationExtractor
+
+Three co-located extractors in one file that characterise tidal-disruption-event (TDE) light curves: a log-linear tail decay fit (`TDETailExtractor`), a physically-motivated rise-and-plateau model fit (`FleetExtractor`), and a measure of inter-band colour variability (`ColorVariationExtractor`).
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/tde_extractor.py`
+- **Versions:** `TDETailExtractor` `1.0.1` / `FleetExtractor` `1.0.2` / `ColorVariationExtractor` `1.0.1`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `scipy.optimize.curve_fit`, `jax` (JIT-compiled model evaluation), `numpy`
+
+---
+
+## Purpose / Meaning
+
+All three extractors are designed to capture morphological signatures of TDE light curves in difference-flux photometry:
+
+- `TDETailExtractor` fits a weighted linear model to the post-peak magnitude decay, expressing it as a log-linear function of time elapsed since peak. TDEs typically show a power-law flux decline, which maps to a linear slope in log-time vs. magnitude space.
+- `FleetExtractor` fits a parametric FLEET-inspired model to the full light curve in magnitude space, capturing both the rise (exponential growth) and the post-peak plateau/decline through a combined `exp + linear` functional form.
+- `ColorVariationExtractor` measures the standard deviation of window-averaged colour (magnitude difference between two bands) as a proxy for chromatic evolution — TDEs tend to show blue, slowly-evolving colour.
+
+---
+
+## Input
+
+### Constructor arguments
+
+#### `TDETailExtractor`
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — (required) | Band identifiers to process, e.g. `["g", "r"]` |
+
+#### `FleetExtractor`
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — (required) | Band identifiers to process |
+
+#### `ColorVariationExtractor`
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `window_len` | `float` | — (required) | Time window length in days for binning observations when computing per-window colour |
+| `band_1` | `str` | — (required) | First (bluer) band identifier |
+| `band_2` | `str` | — (required) | Second (redder) band identifier; colour = `band_1 mag - band_2 mag` |
+
+### `AstroObject` fields read
+
+- `detections` — columns used: `mjd`, `brightness`, `e_brightness`, `fid`, `unit`, `sid`
+- `forced_photometry` — concatenated with `detections` when not `None` (all three extractors do this)
+- `features` — existing feature rows; new rows are appended
+
+### Pre-filtering applied
+
+#### `TDETailExtractor` and `ColorVariationExtractor`
+1. Concatenate `detections` and `forced_photometry` (if present).
+2. Keep only rows with `unit == "diff_flux"`.
+3. Drop rows where `brightness` is `NaN`.
+4. Drop rows where `e_brightness <= 0`.
+5. Convert `brightness` to absolute value, then convert to AB magnitude using `flux2mag` (μJy → AB mag via `-2.5 * log10(flux) + 23.9`).
+6. Convert `e_brightness` to magnitude error using `flux_err_2_mag_err` (`2.5 * flux_err / (ln(10) * flux)`).
+7. Apply `e_brightness < 1.0` and `brightness < 30.0` magnitude-space cuts.
+
+#### `FleetExtractor`
+1. Concatenate `detections` and `forced_photometry` (if present).
+2. Keep only rows with `unit == "diff_flux"`.
+3. Drop rows where `brightness` is `NaN`.
+4. Keep only rows where `brightness > 1` (at least 1 μJy positive signal; operates in flux space).
+5. Drop rows where `e_brightness <= 0`.
+6. Magnitudes are computed inside `compute_features_single_object` (not inside `get_observations`).
+
+### Valid `unit` values
+
+All three extractors require `unit == "diff_flux"` (difference flux in μJy). Rows with any other unit are silently discarded. No magnitude-unit path exists.
+
+---
+
+## Output
+
+Features are appended to `astro_object.features` as rows with columns `name`, `value`, `fid`, `sid`, `version`. `sid` is derived from the sorted unique `sid` values in `astro_object.detections`, joined with commas.
+
+### `TDETailExtractor` features
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `TDE_decay` | per band | Slope coefficient `coeffs[1]` of the weighted linear fit `mag = coeffs[0] + coeffs[1] * 2.5*log10(dt + 40)`. Negative values indicate declining magnitude (brightening flux). |
+| `TDE_decay_chi` | per band | Reduced chi-squared of the linear fit: `sum((fitted - y)^2 / y_err^2) / (N - 2)`. Lower values indicate a better fit. |
+| `TDE_mag0` | per band | Intercept `coeffs[0]` of the fit; an estimate of the effective magnitude at the reference log-time zero. |
+
+Sentinel: `np.nan` for all three features when `len(band_observations) < 2`, or when there are no observations in the window `(t_d, t_d + 200]` days.
+
+### `FleetExtractor` features
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `fleet_a` | per band | Amplitude of the linear (plateau-decay) term in the FLEET model. |
+| `fleet_w` | per band | Exponential rate parameter (must be `<= 0` by bounds); controls the decay speed. |
+| `fleet_chi` | per band | Reduced chi-squared of the model fit: `sum((model - y)^2 / y_err^2) / (N - 4)`. |
+| `fleet_m0` | per band | Magnitude baseline offset (roughly the plateau magnitude). |
+| `fleet_t0` | per band | Time offset parameter (days relative to first observation), shifting the model origin. |
+
+Sentinel: `np.nan` for all five features when `len(band_observations) < 4`, or when `scipy.optimize.curve_fit` raises `RuntimeError` (fit did not converge within `max_nfev=800` evaluations).
+
+### `ColorVariationExtractor` features
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `color_variation` | `"band_1,band_2"` string | Sample standard deviation (`ddof=1`) of per-window mean colour (`band_1 mag - band_2 mag`) across time windows. |
+
+Sentinel: `np.nan` when fewer than 2 valid windows have colour estimates, or when no window has `>= 3` observations in each of the two bands. The `fid` field is the literal string `"g,r"` (or whichever pair was configured), not a single-band identifier.
+
+---
+
+## Underlying library / math
+
+### `TDETailExtractor` — weighted linear regression (NumPy only)
+
+No third-party scientific library is called. The fit is a closed-form weighted least-squares solution via `numpy.linalg.pinv`.
+
+**Model:**
+
+```
+mag(t) = coeffs[0] + coeffs[1] * 2.5 * log10(dt + 40)
+```
+
+where `dt = mjd - t_d` and `t_d` is the MJD of the brightest (minimum magnitude) observation. Only observations in the window `(t_d, t_d + 200]` days are used. The `+ 40` offset prevents `log10(0)` and effectively sets the log-time reference at `dt = -40` days before peak.
+
+**Fit method:** Weighted pseudoinverse (`numpy.linalg.pinv`) of the design matrix `Omega = [1, x]` weighted by `1 / y_err`. The regularisation is implicit in the pseudoinverse but no explicit ridge term is added.
+
+**Chi-squared:** Standard reduced chi-squared with `dof = N - 2`. Returns `np.nan` if `N < 3` (i.e. `chi_den < 1`).
+
+### `FleetExtractor` — `scipy.optimize.curve_fit` + JAX-JIT model
+
+**Function:** `scipy.optimize.curve_fit(fleet_model, x, y, sigma=y_err, p0=..., bounds=..., max_nfev=800)`
+
+`curve_fit` implements nonlinear least-squares using the Levenberg-Marquardt algorithm (or Trust Region Reflective when bounds are provided, which is the case here). It minimises `sum(((f(x, *params) - y) / sigma)^2)`.
+
+**FLEET model** (evaluated by `fleet_model_jax`, JIT-compiled with `jax.jit`):
+
+```
+mag(t) = exp(w * (t - t0)) - a * w * (t - t0) + m_0
+```
+
+where:
+- `t` is time in days relative to the first observation (`mjd - first_mjd`)
+- `a` — linear amplitude (bounds: `[0, 10]`)
+- `w` — exponential rate, constrained `<= 0` (bounds: `[-100, 0]`); a value of `0` collapses the exponential to 1
+- `m_0` — magnitude baseline (bounds: `[0, 30]`)
+- `t0` — time offset in days (bounds: `[-50, 10000]`)
+
+The model captures TDE rise (exponential growth when `w < 0` going backward in time) and subsequent plateau/decline through the interplay of the `exp` and linear terms.
+
+**JAX usage:** `jax.config.update("jax_enable_x64", True)` is called at module import, enabling 64-bit floating point throughout JAX operations. `fleet_model_jax` is decorated with `@jax.jit` for compiled evaluation. The outer `fleet_model` wrapper pads the input array to a multiple of 25 before calling the JIT function (to avoid recompilation on every new input length), then slices back to the original length.
+
+**Initial parameter guess (`p0`):** `[0.6, -0.05, mean(y), 0]` for `[a, w, m_0, t0]`.
+
+**Chi-squared:** Standard reduced chi-squared with `dof = N - 4`. Returns `np.nan` if `N < 5` (i.e. `chi_den < 1`).
+
+### `ColorVariationExtractor` — windowed colour statistics (NumPy / pandas only)
+
+No third-party scientific library is called. Colour per window is the difference of per-band mean magnitudes. The standard deviation uses `numpy.std(..., ddof=1)` (sample std). A window is only included if both bands have `>= 3` observations in that window.
+
+---
+
+## Hardcoded values
+
+### `TDETailExtractor`
+- `200` days — maximum look-ahead window after peak (`t_d + 200`); baked in.
+- `+ 40` days — log-time offset in `2.5 * log10(dt + 40)` to avoid `log(0)`; baked in.
+- `1e-2` — floor added to `y_err` before the fit (`y_err = e_brightness + 1e-2`); baked in.
+- `e_brightness < 1.0` — magnitude error cut; baked in.
+- `brightness < 30.0` — faint-end magnitude cut; baked in.
+
+### `FleetExtractor`
+- `brightness > 1` μJy — minimum flux cut before magnitude conversion; baked in.
+- `1e-2` — floor added to `y_err` (`y_err = flux_err_2_mag_err(...) + 1e-2`); baked in.
+- `p0 = [0.6, -0.05, mean(y), 0]` — initial parameter guess; baked in.
+- `bounds = ([0.0, -100.0, 0, -50], [10, 0, 30, 10000])` — parameter bounds; baked in.
+- `max_nfev = 800` — maximum function evaluations (comment in source: "twice default value"); baked in.
+- `25` — padding block size in `pad()` for JAX recompilation avoidance; baked in.
+- `min_length = 4` — minimum observations per band to attempt fit; baked in.
+- `jax_enable_x64 = True` — set globally at module import time; affects all JAX operations in the process.
+
+### `ColorVariationExtractor`
+- `window_len` — tunable via constructor.
+- `3` — minimum observations per band per window to compute a colour; baked in.
+- `ddof=1` — sample standard deviation; baked in.
+- `e_brightness < 1.0` — magnitude error cut; baked in.
+- `brightness < 30.0` — faint-end magnitude cut; baked in.
+
+---
+
+## Important considerations
+
+- **Flux sign / absolute value:** `TDETailExtractor` (and `ColorVariationExtractor`) take `np.abs(brightness)` before converting to magnitude. This means negative-flux difference epochs are treated as positive detections of the same magnitude. This may conflate pre-peak non-detections or host subtraction artefacts with genuine source flux.
+
+- **Peak definition in `TDETailExtractor`:** The brightest (smallest magnitude after conversion) observation is used to define `t_d`. Because the conversion is `flux2mag(|flux|)`, the peak is the observation with the largest `|diff_flux|`, not necessarily the true photometric peak (host contamination or outliers can shift `t_d`).
+
+- **JAX global state:** The call `jax.config.update("jax_enable_x64", True)` executes at module import. Importing `tde_extractor` anywhere in a process silently switches JAX to 64-bit mode, which affects all other JAX users in that process.
+
+- **JAX recompilation trap:** `fleet_model_jax` is JIT-compiled. The `pad()` function pads to the nearest multiple of 25 to reduce the number of distinct input shapes JAX traces, but does not eliminate recompilation entirely if `N % 25` takes many distinct values across objects.
+
+- **`curve_fit` failure mode:** `RuntimeError` (non-convergence) is caught and results in `np.nan` for all five `fleet_*` features. No other exceptions (e.g. `ValueError` from bad inputs, `LinAlgError`) are caught, so those would propagate.
+
+- **`chi_den < 1` guard:** Both `TDETailExtractor` and `FleetExtractor` check `chi_den >= 1` before dividing; if false they emit `np.nan` for the chi-squared feature. For `TDETailExtractor` this requires `N_after_t_d >= 3`; for `FleetExtractor` it requires `N >= 5`.
+
+- **`fid` encoding for `color_variation`:** The `fid` column is set to the string `"band_1,band_2"` (e.g. `"g,r"`), not a single-band identifier. Downstream consumers must handle this composite string; it does not match the single-character `fid` convention used by the other two extractors.
+
+- **`sid` encoding:** `sid` is constructed by sorting and joining all unique `sid` values from `astro_object.detections` with commas. For multi-survey objects this produces a composite string.
+
+- **No sorting by `mjd`:** None of the three extractors sort observations by `mjd` before processing. `TDETailExtractor` uses `.sort_values("brightness")` only to find the peak. Unsorted input does not cause incorrect results because only scalar statistics and sorted-independent numpy operations are used.
+
+- **In-place mutation:** All three extractors concatenate new rows onto `astro_object.features` in place. Calling the same extractor twice on the same object will duplicate feature rows.
+
+- **Flux unit assumption:** The `flux2mag` function assumes input flux is in μJy: `mag = -2.5 * log10(flux) + 23.9`. If `brightness` is in nJy (LSST native), conversion must happen upstream before these extractors are called. The LSST composite uses `psfFlux / 1000` (nJy → μJy) in `create_astro_object_lsst` before populating `diff_flux` rows.
+
+---
+
+## Cross-references
+
+- **Composites that include these extractors:**
+  - `lc_classifier/lc_classifier/features/composites/ztf.py` — `ZTFFeatureExtractor` includes `TDETailExtractor(["g","r"])`, `FleetExtractor(["g","r"])`, `ColorVariationExtractor(window_len=10, band_1="g", band_2="r")`.
+  - `lc_classifier/lc_classifier/features/composites/lsst.py` — `LSSTFeatureExtractor` includes `TDETailExtractor(["u","g","r","i","z","y"])`, `FleetExtractor(["u","g","r","i","z","y"])`, and five `ColorVariationExtractor` instances for adjacent LSST band pairs (`u-g`, `g-r`, `r-i`, `i-z`, `z-y`), all with `window_len=10`.
+
+- **Consumers of emitted feature names:**
+  - `training/lc_classifier_ztf/feature_computation/compute_features.py` — references `TDE_decay`, `fleet_a`, `fleet_w`, `fleet_chi`, `fleet_m0`, `fleet_t0`, `color_variation` in training feature sets.
+  - `training/lc_classifier_ztf/ATAT_ALeRCE/data/utils.py` — reads these feature names for model input construction.
+  - `lc_anomaly_step/tests/mockdata/features_ztf.py` and `lc_classification_step/tests/mockdata/features_ztf.py` — include mock values for all TDE feature names.
+  - `alerce_classifiers/alerce_classifiers/anomaly/utils.py` — references `color_variation` and FLEET features.
+  - `libs/db-plugins-multisurvey/` — `_initial_data.py` and `_initial_data_pipeline.py` include these feature names in database schema/seed data.
+
+- **Other extractors reading the same `AstroObject` fields:**
+  - `SPMExtractor`, `SNExtractor`, `GPDRWExtractor`, `MHPSExtractor` — all read `detections` and `forced_photometry` with `unit == "diff_flux"`.

--- a/lc_classifier/lc_classifier/features/extractors/docs/timespan_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/timespan_extractor.md
@@ -1,0 +1,76 @@
+# TimespanExtractor
+
+Computes the total time baseline of all detections for an astronomical object, collapsed across all bands and surveys into a single scalar feature.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/timespan_extractor.py`
+- **Version:** `1.0.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** none (only `pandas` and `numpy`, both standard pipeline dependencies)
+
+## Purpose / Meaning
+
+`Timespan` is the elapsed time (in days, MJD difference) between the first and last detection of any kind. It reflects how long the object has been observed regardless of band or survey, which is useful for distinguishing transient events (short timespans) from long-period or persistent variables (long timespans). It also serves as a normalisation denominator for rate-based features computed by other extractors.
+
+## Input
+
+### Constructor arguments
+
+This extractor takes no constructor arguments.
+
+### `AstroObject` fields read
+
+- `detections` — columns: `mjd` (float, Modified Julian Date), `sid` (string survey identifier). No other columns are accessed.
+
+### Pre-filtering applied
+
+None. The extractor reads `astro_object.detections` directly without applying any row filter, NaN drop, band selection, or minimum-length guard.
+
+### Valid `unit` values
+
+Not applicable. The extractor reads only `mjd` and `sid`; it does not branch on any `unit` column.
+
+## Output
+
+One row is appended to `astro_object.features`.
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `Timespan`     | `None`      | `max(mjd) - min(mjd)` across all detections, in days. |
+
+The `sid` field of the output row is a comma-joined, lexicographically sorted string of every unique `sid` value present in `detections` (e.g. `"LSST"` or `"ZTF,LSST"`).
+
+**Sentinel:** no sentinel or `np.nan` is emitted. If `detections` has exactly one row, `Timespan` will be `0.0`. If `detections` is empty, `pandas` will return `NaN` for both `max` and `min`, so the output value will be `NaN` — but the extractor does not guard against an empty DataFrame explicitly.
+
+## Underlying library / math
+
+No third-party scientific library is called. The computation is entirely:
+
+```python
+timespan = detections["mjd"].max() - detections["mjd"].min()
+```
+
+This is a straightforward range (peak-to-peak) operation on the `mjd` column using `pandas.Series.max` and `pandas.Series.min`.
+
+## Hardcoded values
+
+There are no numeric literals in the extractor body. All behaviour is fully determined by the content of `detections["mjd"]`.
+
+## Important considerations
+
+- **No minimum-length guard.** A single detection produces `Timespan = 0.0`. The extractor will not short-circuit or warn.
+- **Empty detections DataFrame.** `pandas` `max()` and `min()` on an empty Series return `NaN` (with a `RuntimeWarning` in some pandas versions), so `Timespan` would be `NaN`. There is no explicit guard.
+- **NaN propagation in `mjd`.** If any `mjd` value is `NaN`, `pandas` `max`/`min` silently skip NaNs by default (`skipna=True`), so the result is computed from the remaining valid values with no error or warning to the caller.
+- **Multi-survey `sid` encoding.** The `sid` column of the output row is a single comma-joined string (e.g. `"LSST,ZTF"`), not a list. Consumers that split on `","` must handle single-survey objects (no comma present) as a special case.
+- **Mutates `astro_object.features` in place.** The extractor concatenates via `pd.concat` and reassigns `astro_object.features`; the original DataFrame reference held by the caller is replaced.
+- **`fid` is `None`.** Unlike per-band extractors, `Timespan` uses `fid=None` because it aggregates across all bands. Consumers must not assume a non-null `fid` for this feature.
+- **No forced photometry.** `astro_object.forced_photometry` is never read. The timespan reflects only the formal detections, not forced-photometry epochs, regardless of how the object was constructed.
+- **Survey ordering.** `sids` are sorted with `np.sort` (lexicographic on strings) before joining, so the `sid` string is deterministic regardless of detection ordering.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `ZTFFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/ztf.py`)
+  - `LSSTFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/lsst.py`)
+  - `ElasticcFeatureExtractor` (`lc_classifier/lc_classifier/features/composites/elasticc.py`)
+- **Other extractors reading the same fields:** any extractor that reads `detections["mjd"]` (e.g. period, variability, and color extractors).
+- **Consumers of `Timespan`:** not detected via grep in the extractor or composite layer; downstream model code outside `lc_classifier` may use the feature by name.

--- a/lc_classifier/lc_classifier/features/extractors/docs/turbofats_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/turbofats_extractor.md
@@ -1,0 +1,161 @@
+# TurboFatsExtractor
+
+Computes 26 single-band statistical and variability features per photometric band using the in-repo `turbofats` library.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/turbofats_extractor.py`
+- **Version:** `1.1.0`
+- **Base class:** `FeatureExtractor`
+- **External libs:** `turbofats` (in-repo at `lc_classifier/lc_classifier/features/turbofats/`), `scipy`, `statsmodels`, `numba`
+
+## Purpose / Meaning
+
+Extracts a broad suite of time-domain statistics (scatter, variability, shape, and time-correlation features) from a single photometric band at a time. The features characterise the brightness distribution, autocorrelation structure, intrinsic variability, and temporal trends of a light curve and are widely used as discriminating inputs to light-curve classifiers.
+
+## Input
+
+### Constructor arguments
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — (required) | Band identifiers to iterate over; one feature row set is emitted per band. |
+| `unit` | `str` | — (required) | Photometric unit. Must be `"magnitude"` or `"diff_flux"`. Raises `ValueError` otherwise. |
+
+### `AstroObject` fields read
+
+- `detections` — columns: `unit`, `brightness`, `mjd`, `fid`, `sid`, `e_brightness`.
+
+### Pre-filtering applied
+
+1. Rows where `detections["unit"] != self.unit` are dropped.
+2. Rows where `detections["brightness"]` is `NaN` are dropped.
+3. Duplicate `mjd` values are dropped (first occurrence kept by `drop_duplicates`).
+4. Per band: rows matching `fid == band` are extracted and sorted ascending by `mjd`.
+5. `FeatureSpace.calculate_features` returns all-`NaN` sentinels if the resulting band lightcurve has **≤ 5** observations.
+
+### Valid `unit` values
+
+- `"magnitude"` — raw magnitude values; feature names are emitted as-is.
+- `"diff_flux"` — difference-image flux; feature names are suffixed with `"_flux"` in the output (e.g. `Amplitude_flux`).
+
+## Output
+
+Every row appended to `astro_object.features` has columns `name`, `value`, `fid`, `sid`, `version`.
+
+`fid` is the band identifier (one set of rows per band in `self.bands`).  
+`sid` is a comma-joined, sorted string of all unique survey identifiers (`sid`) present across the filtered detections.
+
+All features return `np.nan` if the band has ≤ 5 detections (enforced in `FeatureSpace.calculate_features`). Any exception raised inside a single feature's `fit()` call is caught, a warning is issued, and the value is set to `np.nan`.
+
+| Feature `name` | Meaning |
+|----------------|---------|
+| `Amplitude` | Half the difference between the median of the top 5 % and the median of the bottom 5 % of sorted brightness values. |
+| `AndersonDarling` | Anderson-Darling normality test statistic, passed through a sigmoid: `1 / (1 + exp(-10 * (A - 0.3)))`. Bounded in (0, 1); higher = less Gaussian. |
+| `Autocor_length` | Lag (integer count) at which the sample autocorrelation function first drops below `exp(-1) ≈ 0.368`. Computed with `statsmodels.tsa.stattools.acf` starting at `nlags=100`, extending by 100 each time the threshold is not reached. Returns the light-curve length if `nlags` exceeds the number of observations. |
+| `Beyond1Std` | Fraction of points that lie more than one standard deviation from the error-weighted mean. Standard deviation is computed relative to the weighted mean, not the sample mean. |
+| `Con` | Fraction of consecutive triplets of measurements all lying outside 2σ of the mean. σ and mean are unweighted. Denominator is `N - 2`. Returns 0 if `N < 3`. |
+| `Eta_e` | Time-weighted version of the von Neumann η statistic: `(1/σ²) × (Σ wᵢ Δmᵢ²) / (Σ wᵢ)`, where weights are `wᵢ = 1/(tᵢ₊₁ - tᵢ)²`. Small values indicate smooth time evolution. |
+| `Gskew` | Median-based skewness: `median(m ≤ p3) + median(m ≥ p97) − 2 × median(m)`, where `p3` and `p97` are the 3rd and 97th percentiles. |
+| `MaxSlope` | Maximum absolute first difference in brightness divided by the corresponding time interval (units: brightness unit per day). Computed on time-sorted data. |
+| `Mean` | Arithmetic mean of brightness values. |
+| `Meanvariance` | Ratio of standard deviation to mean: `std / mean`. Dimensionless variability index. Note: undefined / numerically unstable if `mean ≈ 0` (relevant for `diff_flux` unit). |
+| `MedianAbsDev` | Median absolute deviation from the median: `median(|m − median(m)|)`. |
+| `MedianBRP` | Median buffer range percentage: fraction of points within `(max − min) / 10` of the median. |
+| `PairSlopeTrend` | For the last 30 (time-sorted) observations: `(#increasing differences − #non-increasing differences) / 30`. Bounded in [−1, 1]. If fewer than 30 points exist, the last `N` points are used (Python slice `[-30:]`), but the denominator remains 30. |
+| `PercentAmplitude` | Maximum absolute deviation from the median divided by the median: `max(|m − median|) / median`. |
+| `Q31` | Interquartile range: 75th percentile minus 25th percentile. |
+| `Rcs` | Range of cumulative sum: `max(S) − min(S)` where `S[k] = Σᵢ₌₀ᵏ (mᵢ − m̄) / (N × σ)`. |
+| `Skew` | Fisher skewness of brightness values via `scipy.stats.skew`. |
+| `SmallKurtosis` | Small-sample excess kurtosis (bias-corrected formula for `n < 300`). |
+| `Std` | Sample standard deviation of brightness values (`numpy.std`, ddof=0). |
+| `StetsonK` | Robust kurtosis measure: `(1/√N) × Σ|δᵢ| / √(Σδᵢ²)`, where `δᵢ = √(N/(N−1)) × (mᵢ − m̄_w) / σᵢ` and `m̄_w` is the error-weighted mean. |
+| `Pvar` | Probability of intrinsic variability: chi-squared CDF `Fχ²(χ², N−1)` where `χ² = Σ (mᵢ − m̄)² / σᵢ²`. |
+| `ExcessVar` | Excess variance: `Σ((mᵢ − m̄)² − σᵢ²) / (N × m̄²)`. Measures intrinsic variability amplitude. |
+| `SF_ML_amplitude` | Amplitude parameter `A` of the structure function model `SF(τ) = A × τ^γ`, fitted by log-linear regression on binned SF values in the range `0.01 ≤ τ/365 ≤ 0.5` days. Sentinel −0.5 if fit cannot be computed. Clipped to [0.005, 15]; set to 0 if below 0.005. |
+| `SF_ML_gamma` | Power-law index `γ` from the same structure function fit. Retrieved from `shared_data` set by `SF_ML_amplitude`. Clipped to [−0.5, 3.0]. Sentinel −0.5 if fit cannot be computed. |
+| `IAR_phi` | Autoregressive coefficient φ ∈ (0, 1) of an Irregular AutoRegressive (IAR) model, fitted by maximum likelihood via a Kalman filter using `scipy.optimize.minimize_scalar` with `method="bounded"` and `xatol=1e-12`, `maxiter=50000`. Magnitude is standardised before fitting. |
+| `LinearTrend` | Ordinary least-squares slope of brightness on `mjd` via `scipy.stats.linregress`. Units: brightness unit per day. |
+
+### Flux-unit name suffix
+
+When `unit == "diff_flux"`, every feature name listed above has `"_flux"` appended (e.g. `Amplitude_flux`, `IAR_phi_flux`).
+
+## Underlying library / math
+
+All feature classes live in `lc_classifier/lc_classifier/features/turbofats/FeatureFunctionLib.py` and three sub-modules under `features/`. They are instantiated once at constructor time and reused across all `compute_features_single_object` calls.
+
+### `FeatureSpace` (in-repo, `turbofats/FeatureSpace.py`)
+
+- Accepts the feature name list; instantiates the corresponding classes from `FeatureFunctionLib` via `getattr`.
+- Passes a single `shared_data` dict to every feature instance; features like `SF_ML_gamma` and `IAR_phi` rely on values deposited in `shared_data` by a previously-run feature (`SF_ML_amplitude`). **The feature execution order is therefore load-bearing.**
+- Input array layout: `data[0] = brightness`, `data[1] = mjd`, `data[2] = e_brightness` (extracted by `FeatureSpace.__lightcurve_to_array` from columns `["brightness", "mjd", "e_brightness"]`).
+- `shared_data` is cleared at the start of every `calculate_features` call.
+
+### `IAR_phi` (`features/irregular_autoregressive.py`)
+
+- **Algorithm:** Irregular AutoRegressive (IAR) model with Kalman filter (Elorrieta et al.). Log-likelihood is evaluated in a `@jit(nopython=True)` kernel `iar_phi_kalman_numba`.
+- **Optimisation:** `scipy.optimize.minimize_scalar` bounded on `(0, 1)`.
+- **Hardcoded options:** `xatol=1e-12`, `maxiter=50000`.
+- If `|phi| >= 1` inside the Kalman loop, the likelihood is pinned to `1e10`.
+
+### `SF_ML_amplitude` / `SF_ML_gamma` (`features/structure_function.py`)
+
+- **Algorithm:** Fits `SF(τ) = A × τ^γ` by log-linear regression (`numpy.polyfit`) on structure function values binned in log-τ space (bin width 0.1 dex, range 5–2000 days). Only τ values between 0.01 and 0.5 years enter the regression.
+- All pairs `(i, j)` are computed via a `@jit(nopython=True)` loop. This is O(N²) in the number of observations.
+- `SF_ML_gamma` reads its result from `shared_data["g_sf"]`; raises an `Exception` (not swallowed) if `SF_ML_amplitude` has not run first.
+
+### `AndersonDarling`
+
+- Calls `scipy.stats.anderson(magnitude)` and takes only the test statistic (index 0), ignoring the critical-value table.
+- Applies a fixed sigmoid with centre 0.3 and scale 10; these constants are baked in.
+
+### `Autocor_length`
+
+- Uses `statsmodels.tsa.stattools.acf` with `fft=False` (direct method).
+- Initial `nlags=100`, doubled each iteration if threshold not met; cap is `len(magnitude)`.
+
+### `CAR_sigma` / `CAR_tau` / `CAR_mean` (`features/conditional_autoregressive.py`)
+
+These classes are imported by `FeatureFunctionLib.py` but **none of them appear in the 26-feature list** used by `TurboFatsExtractor`. They are present in the codebase but not activated here.
+
+## Hardcoded values
+
+| Value | Location | Tunable? |
+|-------|----------|----------|
+| `> 5` observations required | `FeatureSpace.calculate_features` | No |
+| `nlags = 100` initial lag for `Autocor_length` | `FeatureFunctionLib.Autocor_length.__init__` | Via `extra_arguments` in `FeatureSpace.__init__`, but not exposed by `TurboFatsExtractor` |
+| `consecutiveStar = 3` for `Con` | `FeatureFunctionLib.Con.__init__` | Via `extra_arguments`; not exposed |
+| `2σ` threshold for `Con` | `FeatureFunctionLib.Con.fit` | No |
+| Top/bottom `5 %` for `Amplitude` | `FeatureFunctionLib.Amplitude.fit` | No |
+| Sigmoid centre `0.3`, scale `10` for `AndersonDarling` | `FeatureFunctionLib.AndersonDarling.fit` | No |
+| Last `30` observations for `PairSlopeTrend` (denominator always 30) | `FeatureFunctionLib.PairSlopeTrend.fit` | No |
+| Percentiles `3`, `97` for `Gskew` | `FeatureFunctionLib.Gskew.fit` | No |
+| SF τ range: 5–2000 days, bin width 0.1 dex | `SF_ML_amplitude.bincalc` | No |
+| SF fit τ window: 0.01–0.5 years | `SF_ML_amplitude.fit` | No |
+| SF sentinel: `a = −0.5`, `gamma = −0.5` | `SF_ML_amplitude.fit` | No |
+| SF amplitude clip: [0.005, 15] | `SF_ML_amplitude.fit` | No |
+| SF gamma clip: [−0.5, 3.0] | `SF_ML_amplitude.fit` | No |
+| IAR bounds: `(0, 1)` | `IAR_phi.fit` | No |
+| IAR options: `xatol=1e-12`, `maxiter=50000` | `IAR_phi.fit` | No |
+| `shared_data` key ordering (execution order determines dependency resolution) | `FeatureSpace.calculate_features` | No |
+
+## Important considerations
+
+- **Minimum length:** `FeatureSpace.calculate_features` returns all-`NaN` for any band with ≤ 5 detections after filtering. No other short-circuit exists in the extractor itself.
+- **Execution order dependency:** `SF_ML_gamma` requires `SF_ML_amplitude` to run first (uses `shared_data["g_sf"]`). The 26-feature list in the constructor preserves this order (`"SF_ML_amplitude"` before `"SF_ML_gamma"`). Reordering the list would silently break `SF_ML_gamma`.
+- **Exception swallowing:** Any `Exception` raised inside a feature's `fit()` is caught by `FeatureSpace.calculate_features`, a `warnings.warn` is issued, and the value is set to `np.nan`. Failures are not propagated and may be invisible in production.
+- **In-place mutation:** `astro_object.features` is replaced with a new concatenated `DataFrame`. Empty band DataFrames are silently skipped.
+- **`Meanvariance` near zero:** For `unit="diff_flux"` the mean flux can be near zero, making `std / mean` numerically unstable or very large. No guard is present.
+- **`PairSlopeTrend` denominator is always 30**, even when fewer than 30 observations are present (Python slice `[-30:]` silently clips). The returned value is not bounded to [−1, 1] in that case but is bounded if exactly 30 points are used.
+- **`sid` encoding:** `sid` is produced by joining all unique survey IDs present in the filtered (all-band) detections with `","` — not restricted to the current band. Bands with zero detections are still processed and will emit `NaN` rows, though their `sid` reflects the global detection pool.
+- **`numba` JIT compilation:** `iar_phi_kalman_numba`, `SFarray`, and `is_sorted` are decorated with `@jit(nopython=True)`. First-call compilation overhead occurs at import or first invocation. dtype mismatches can raise `numba.core.errors.TypingError` at runtime (swallowed to `np.nan` by the outer catch).
+- **No `e_brightness` guard:** `StetsonK`, `Beyond1Std`, `Pvar`, `ExcessVar`, `IAR_phi`, `SF_ML_amplitude`, and `SF_ML_gamma` all consume `e_brightness`. If all error values are zero, `StetsonK` will divide by zero; `IAR_phi` explicitly handles this by substituting a zero array. Other features do not guard against zero errors.
+- **Stateful `shared_data`:** The same `shared_data` dict is reused across objects; `FeatureSpace.calculate_features` calls `self.shared_data.clear()` at the start of each call, preventing cross-object contamination.
+
+## Cross-references
+
+- **Composites that include this extractor:**
+  - `lc_classifier/lc_classifier/features/composites/ztf.py` — `TurboFatsExtractor(bands=["g","r"], unit="magnitude")`
+  - `lc_classifier/lc_classifier/features/composites/lsst.py` — `TurboFatsExtractor(bands=["u","g","r","i","z","y"], unit="magnitude")`
+  - `lc_classifier/lc_classifier/features/composites/elasticc.py` — `TurboFatsExtractor(bands=list("ugrizY"), unit="diff_flux")` (output names gain `_flux` suffix)
+- **Other extractors reading the same `detections` fields:** Most extractors in the same composites (`MHPSExtractor`, `FoldedKimExtractor`, `HarmonicsExtractor`, etc.) also read `brightness`, `mjd`, `e_brightness`, `fid`, and `unit` from `detections`.
+- **Consumers of emitted feature names:** No other extractor was found reading the turbofats feature names from `astro_object.features`. They are consumed downstream by the classifier models.

--- a/lc_classifier/lc_classifier/features/extractors/docs/ulens_extractor.md
+++ b/lc_classifier/lc_classifier/features/extractors/docs/ulens_extractor.md
@@ -1,0 +1,140 @@
+# MicroLensExtractor
+
+Fits the five-parameter Paczynski microlensing model to each photometric band of a light curve and returns the best-fit parameters plus the reduced chi-squared goodness-of-fit.
+
+- **Source:** `lc_classifier/lc_classifier/features/extractors/ulens_extractor.py`
+- **Version:** `1.0.2`
+- **Base class:** `FeatureExtractor` (abstract, from `lc_classifier.features.core.base`)
+- **External libs:** `scipy.optimize.curve_fit`, `jax`, `jax.numpy`, `numpy`, `pandas`
+
+## Purpose / Meaning
+
+Microlensing events produce a smooth, achromatic, time-symmetric brightening that is well described by the Paczynski (1986) model. Fitting this model and inspecting the residuals gives classifiers a compact, physically motivated representation of whether an object's light curve is consistent with gravitational microlensing, which is otherwise difficult to distinguish from other single-peak transients (novae, AGN flares, etc.) using only statistical features.
+
+## Input
+
+### Constructor arguments
+
+| Name | Type | Default | Meaning |
+|------|------|---------|---------|
+| `bands` | `List[str]` | — (required) | Photometric band identifiers to iterate over (e.g. `["g", "r"]`). One independent fit is performed per band. |
+
+### `AstroObject` fields read
+
+- `detections` — columns used: `mjd`, `brightness`, `e_brightness`, `fid`, `unit`, `sid`.
+- `forced_photometry` — when not `None`, concatenated with `detections` before filtering. Columns used: same as `detections`.
+
+### Pre-filtering applied
+
+1. `detections` and `forced_photometry` (if present) are concatenated along `axis=0`.
+2. Rows where `unit != "magnitude"` are dropped (`self.unit = "magnitude"` is hardcoded).
+3. Rows where `brightness` is `NaN` are dropped.
+4. Rows where `e_brightness >= 1.0` are dropped.
+5. The `mjd` column is shifted so that `min(mjd) == 0` across the combined observation table.
+6. Per band, the band subset is used directly (no sort; order is inherited from the concatenated DataFrame).
+7. If fewer than 4 observations remain in a band, all six features for that band are emitted as `np.nan` and the band is skipped.
+
+### Valid `unit` values
+
+Only `"magnitude"` is accepted. This is a class-level constant (`unit = "magnitude"`), not a constructor argument. Any observation with a different `unit` value is silently dropped during pre-filtering; no exception is raised.
+
+## Output
+
+Every row appended to `astro_object.features` has columns `name`, `value`, `fid`, `sid`, `version`.
+
+`sid` is derived from the unique `sid` values in `astro_object.detections` (the original detections, not the merged+filtered table), sorted and joined with a comma. `version` is `"1.0.2"`.
+
+For each band in `self.bands`, six features are appended:
+
+| Feature `name` | `fid` scope | Meaning |
+|----------------|-------------|---------|
+| `ulens_u0` | per band | Fitted impact parameter `u0` — the minimum projected lens-source separation in units of the Einstein radius. Bounded `[0, +inf)`. |
+| `ulens_tE` | per band | Fitted Einstein crossing time `tE` in days. Bounded `[0, +inf)`. |
+| `ulens_fs` | per band | Fitted source flux fraction `fs` — the fraction of total baseline flux contributed by the lensed source. Bounded `[0, 1]`. |
+| `ulens_chi` | per band | Reduced chi-squared of the fit: `sum((model - y)^2 / sigma^2) / (N - 4)`. |
+| `ulens_t0` | per band | Fitted time of closest approach `t0` in days (in the shifted `mjd` frame where `min(mjd) = 0`). Unbounded. |
+| `ulens_mag0` | per band | Fitted baseline magnitude `mag_0`. Unbounded. |
+
+**Sentinel value:** `np.nan`. Emitted for all six features in a band when either (a) fewer than 4 observations are available after filtering, or (b) `scipy.optimize.curve_fit` raises `RuntimeError` (optimizer did not converge or exceeded `max_nfev`).
+
+**`ulens_chi` special case:** if `len(observations_in_band) - 4 < 1` (i.e. exactly 4 observations), the denominator of the reduced chi-squared is less than 1, and `ulens_chi` is emitted as `np.nan` even when the fit succeeded. Specifically, `chi_den = len(model_prediction) - 4`, and `ulens_chi` is `np.nan` when `chi_den < 1`.
+
+## Underlying library / math
+
+### Microlensing model (inline)
+
+The Paczynski point-source/point-lens magnification model is implemented directly in the extractor as `ulens_model_jax`:
+
+```
+t' = t - t0
+u  = sqrt(u0^2 + (t' / tE)^2)
+A  = (u^2 + 2) / (u * sqrt(u^2 + 4))
+m(t) = -2.5 * log10(fs * (A - 1) + 1) + mag_0
+```
+
+- `u` is the dimensionless lens-source separation as a function of time.
+- `A` is the standard Paczynski point-source magnification (diverges as `u -> 0`).
+- `fs` blends the magnified source with an unlensed component: when `fs = 1` the model is pure microlensing; when `fs < 1` additional constant (blended) flux is present.
+- The model is in magnitude space, with `mag_0` as the baseline magnitude.
+
+The JAX-compiled function `ulens_model_jax` is decorated with `@jax.jit` (imported as `jax_jit`). The wrapper `ulens_model` pads the time array to a multiple of 25 before passing it to the JIT-compiled function, then trims the output back to the original length. This padding is required to avoid JAX recompilation for every distinct array length.
+
+`jax.config.update("jax_enable_x64", True)` is called at module import time, enabling 64-bit floating point throughout JAX computation.
+
+### `scipy.optimize.curve_fit`
+
+- **Function:** `scipy.optimize._minpack_py.curve_fit(f, xdata, ydata, p0, sigma, bounds, max_nfev)`
+- **Algorithm:** Levenberg-Marquardt or Trust Region Reflective nonlinear least-squares (TRF is selected automatically when `bounds` are finite, which is the case here for `u0`, `tE`, and `fs`).
+- **`sigma` treatment:** `absolute_sigma` is not set (defaults to `False`), meaning `sigma` values are treated as relative weights only. The returned covariance matrix (discarded by the extractor via `_`) is scaled to match sample variance. The `sigma` passed is `e_brightness + 1e-2`, so the floor ensures no zero-weight observations even when `e_brightness = 0`.
+- **`max_nfev=1000`:** overrides the library default. With bounds active (TRF method), the library default would be `100 * (N + 1)` where `N = 5` (number of parameters), giving 600. The extractor explicitly sets `max_nfev=1000`, described in a comment as "twice default value" — this comment reflects the `leastsq` default (`200 * (N + 1) = 1200`) rather than the TRF default; the actual ratio depends on the solver selected.
+- **`RuntimeError`:** raised by `curve_fit` when the optimizer fails to converge within `max_nfev` evaluations. Caught explicitly; all six features are emitted as `np.nan`.
+- **Covariance output:** the covariance matrix `_` is discarded. No parameter uncertainties are stored as features.
+
+## Hardcoded values
+
+| Literal | Location | Tunable? | Meaning |
+|---------|----------|----------|---------|
+| `self.unit = "magnitude"` | class body | No | Only magnitude-unit observations are accepted. |
+| `min_band_length = 4` | `compute_features_single_object` | No | Minimum number of per-band observations required to attempt a fit. |
+| `e_brightness` floor `1e-2` | `get_observations` | No | Added to every `e_brightness` value before passing as `sigma` to `curve_fit`, preventing zero-weight observations. |
+| `p0 = [0.6, 20.0, 0.5, mjd_max_flux, np.median(y)]` | `compute_features_single_object` | No | Initial parameter guess: `u0=0.6`, `tE=20 days`, `fs=0.5`, `t0` at brightest observed epoch, `mag_0` at median magnitude. |
+| `bounds = ([0, 0, 0, -inf, -inf], [inf, inf, 1, inf, inf])` | `compute_features_single_object` | No | Physical bounds: `u0 >= 0`, `tE >= 0`, `0 <= fs <= 1`; `t0` and `mag_0` are unconstrained. |
+| `max_nfev = 1000` | `compute_features_single_object` | No | Maximum optimizer function evaluations. Comment says "twice default value". |
+| `chi_den = len(model_prediction) - 4` | `compute_features_single_object` | No | Degrees of freedom for reduced chi-squared. Subtracts 4, not 5 (the number of free parameters), which may be an off-by-one — intent is unclear from the source. |
+| `pad_length` multiple of 25 | `pad` | No | Array padding to stabilise JAX JIT trace cache: input length is rounded up to next multiple of 25. |
+| `jax_enable_x64 = True` | module level | No | Forces 64-bit floats in JAX; set globally at import time, affecting all JAX computations in the process. |
+
+## Important considerations
+
+**Off-by-one in degrees of freedom:** `chi_den = len(model_prediction) - 4` subtracts 4 from the number of observations, but the model has 5 free parameters (`u0`, `tE`, `fs`, `t0`, `mag_0`). The standard reduced chi-squared denominator for 5 parameters would be `N - 5`. Whether the subtraction of 4 is intentional is not documented in the source.
+
+**`t0` is in the shifted MJD frame:** `get_observations` shifts `mjd` by subtracting the minimum across the merged (detections + forced photometry) table. The fitted `ulens_t0` is therefore not in absolute MJD; a consumer that needs an absolute time must add back the original `min(mjd)`, which is not stored anywhere in `astro_object`.
+
+**`mjd_max_flux` initial guess:** the initial `t0` guess is derived as the `mjd` of the observation with the smallest `brightness` value (since `sort_values("brightness").iloc[0]` gives the minimum, which in magnitude scale is the brightest point). This is correct for the initial guess but assumes brightness is in magnitudes (lower = brighter), consistent with `self.unit = "magnitude"`.
+
+**JAX global state mutation:** `jax.config.update("jax_enable_x64", True)` runs at module import time. Importing `ulens_extractor` therefore changes the JAX float precision for the entire Python process, which may affect other JAX code running in the same environment.
+
+**JAX JIT recompilation boundary:** the `pad` function pads arrays to the next multiple of 25. Arrays whose lengths map to different multiples of 25 will each trigger a separate JIT compilation. For short light curves (common in classification pipelines), the padded length is likely 25 for all bands, minimising recompilation.
+
+**No sorting by `mjd`:** unlike many other extractors, `get_observations` does not sort by `mjd`. The time array passed to `curve_fit` follows the concatenation order of `detections` and `forced_photometry`. `curve_fit` with TRF does not require sorted inputs, so this is not a correctness issue, but it means `mjd_max_flux` (derived via `sort_values("brightness").iloc[0]["mjd"]`) is the MJD of the globally brightest point, which may differ from the chronological peak if there are repeated brightness values.
+
+**Only `RuntimeError` is caught:** `curve_fit` may also raise `ValueError` (e.g. if residuals are not finite after JAX computation produces `inf` or `nan` at extreme parameter values). A `ValueError` from `curve_fit` would propagate uncaught to the caller.
+
+**In-place mutation:** `compute_features_single_object` appends to `astro_object.features` via `pd.concat`, consistent with the `FeatureExtractor` contract (`"""This method is inplace"""`).
+
+**`sid` source:** `sid` is read from `astro_object.detections["sid"].unique()`, not from the merged+filtered observation table. If all detections are filtered out by the `unit` filter but `forced_photometry` contributes observations, `sid` will still be populated from the original detections.
+
+## Cross-references
+
+**Composites that include this extractor:**
+
+- `lc_classifier/lc_classifier/features/composites/ztf.py` — instantiated as `MicroLensExtractor(bands)` with `bands = ["g", "r"]`.
+- `lc_classifier/lc_classifier/features/composites/lsst.py` — instantiated as `MicroLensExtractor(bands)` with `bands = list("ugrizy")` (exact band list depends on the composite constructor argument).
+
+**Tests:**
+
+- `lc_classifier/tests/features/test_ulens_extractor.py` — exercises with ZTF forced-photometry training examples, `bands=list("gr")`.
+
+**Other extractors sharing the same `AstroObject` fields:**
+
+- Any extractor reading `detections["brightness"]` in magnitude units shares the same underlying data. No output features from `MicroLensExtractor` are consumed as inputs by other extractors in this repository.


### PR DESCRIPTION
## Summary
  - Adds initial reference markdown docs for 17 feature extractors under `lc_classifier/lc_classifier/features/extractors/docs/`
  - Includes a `NOTABLE_FINDINGS.md` summarizing findings across extractors

  ## Test plan
  - [ ] Review each extractor doc for accuracy of inputs/outputs/hardcoded values
  - [ ] Verify links between docs (if any) resolve correctly