### PR TITLE
Revive legacy metadata_step on the multi-survey schema (i-band fix + vendored models + on-prem creds) + CI overlay support

### DIFF
--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -271,7 +271,7 @@ ML model that classifies alerts based on their stamps. One instance per survey (
 ### Other legacy steps
 
 - **early_classification_step** — Pre-feature classifier. **TODO:** input/output topics not enumerated here; check chart values.
-- **metadata_step** — ZTF-specific. Consumes `sorting-hat-ztf`, parses ZTF `extra_fields` (PS1, Gaia cross-match data), and writes detection metadata to PSQL. No Kafka output.
+- **metadata_step** — ZTF-specific. Consumes `sorting-hat` (production consumes `sorting-hat`; the chart default `values.yaml` still lists `sorting-hat-ztf`), parses ZTF `extra_fields` (PS1, Gaia cross-match data), and writes the crossmatch metadata tables (`reference`, `ss_ztf`, `ps1_ztf`, `dataquality`, `gaia_ztf`) **directly** to PSQL via on-conflict upsert — not through scribe. No Kafka data output (metrics only).
 - **watchlist_step** — Crossmatches alerts against user-defined watchlists; notifies users on hits.
 - **alert_archiving_step** — Archives raw Avro alerts to S3 in daily-partitioned paths (`avro_YYYYMMDD/`, snappy codec). Configured for ZTF and ATLAS buckets.
 - **s3_step** — Uploads Avro files to an AWS S3 bucket (legacy archival).

--- a/charts/metadata_step/Chart.yaml
+++ b/charts/metadata_step/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 27.5.7a37
+appVersion: 27.5.7a40
 description: A Helm chart for Kubernetes
 name: metadata-step
 type: application
-version: 27.5.7-37
+version: 27.5.7-40

--- a/ci/build.py
+++ b/ci/build.py
@@ -37,6 +37,7 @@ async def _build_package(packages: dict, dry_run: bool):
                         build_args,
                         pkg,
                         dry_run,
+                        packages[pkg].get("tag"),
                     )
                 else:
                     tg.start_soon(

--- a/ci/cli_build.py
+++ b/ci/cli_build.py
@@ -68,7 +68,7 @@ def direct(
     """
     build_args_names = []
     build_args_values = []
-    for a in build_args:
+    for a in build_args or []:
         name, value = a.split(":")
         build_args_names.append(name)
         build_args_values.append(value)

--- a/ci/cli_build.py
+++ b/ci/cli_build.py
@@ -60,16 +60,21 @@ def direct(
     package: str,
     package_dir: str = None,
     build_args: Annotated[Optional[List[str]], typer.Option()] = None,
+    tag: str = None,
     stage: Stage = Stage.staging,
     dry_run: bool = False,
 ):
     """
     Builds a single package.
+
+    --tag overrides the version-derived tags (["rc", <poetry version>]) with a single
+    explicit tag. Use it for overlay images that must not clobber the canonical tag
+    (e.g. a cfk-bumped quimal variant published as <version>-cfk2.14.2).
     """
     build_args_names = []
     build_args_values = []
     for a in build_args or []:
-        name, value = a.split(":")
+        name, value = a.split(":", 1)
         build_args_names.append(name)
         build_args_values.append(value)
 
@@ -78,6 +83,7 @@ def direct(
         "build-arg": build_args_names,
         "value": build_args_values,
         "package-dir": package if package_dir is None else package_dir,
+        "tag": tag,
     }
 
     _build(package_dict, dry_run)

--- a/ci/utils.py
+++ b/ci/utils.py
@@ -110,6 +110,7 @@ async def build(
     build_args: list,
     output_package_name,
     dry_run: bool,
+    tag_override: str = None,
 ):
     path = pathlib.Path().cwd().parent.absolute()
     # get build context directory
@@ -136,7 +137,7 @@ async def build(
         dockerfile=f"{package_dir}/Dockerfile",
         build_args=bargs,
     )
-    tags = await get_tags(client, package_dir)
+    tags = [tag_override] if tag_override else await get_tags(client, package_dir)
     print(f"Built image with tag: {tags}")
 
     if not dry_run:

--- a/metadata_step/Dockerfile
+++ b/metadata_step/Dockerfile
@@ -46,4 +46,17 @@ COPY metadata_step/README.md \
 WORKDIR /app
 RUN poetry install --only-root
 
+# Optional image-build overlay: override confluent-kafka in the in-project venv.
+# No-op when the build-arg is empty, so default (AWS) builds are unchanged. Needed
+# for the quimal SCRAM-SHA-512 broker: the lock pins confluent-kafka ~2.0.2, whose
+# librdkafka 2.0.2 has a SCRAM bug surfacing as a bogus "invalid credentials"
+# (same blocker as the watchlist-step -cfk2.14.2 overlay). This is an image-layer
+# bump, NOT a poetry re-lock (re-locking conflicts with apf multisurvey; see
+# aws_cost_analysis/docs/metadata-step-revival-plan.md §7).
+ARG CONFLUENT_KAFKA_VERSION=
+RUN if [ -n "$CONFLUENT_KAFKA_VERSION" ]; then \
+      /app/.venv/bin/pip install --no-cache-dir --upgrade "confluent-kafka==$CONFLUENT_KAFKA_VERSION" && \
+      /app/.venv/bin/python -c "import confluent_kafka as k; print('cfk overlay:', k.__version__, 'librdkafka', k.libversion())"; \
+    fi
+
 CMD ["poetry", "run", "python", "scripts/run_step.py"]

--- a/metadata_step/metadata_step/step.py
+++ b/metadata_step/metadata_step/step.py
@@ -16,7 +16,7 @@ class MetadataStep(GenericStep):
         self.db = db_sql
 
     def _format_detection(self, d: Dict, catalogs: Dict):
-        FID = {"g": 1, "r": 2}
+        FID = {"g": 1, "r": 2, "i": 3}
         d = d.copy()
         d["fid"] = FID[d["fid"]]
         extra_fields = d.pop("extra_fields")

--- a/metadata_step/metadata_step/utils/database.py
+++ b/metadata_step/metadata_step/utils/database.py
@@ -6,7 +6,13 @@ import logging
 from sqlalchemy import create_engine, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import sessionmaker, Session
-from db_plugins.db.sql.models import Reference, Gaia_ztf, Ss_ztf, Dataquality, Ps1_ztf
+from metadata_step.utils.legacy_models import (
+    Reference,
+    Gaia_ztf,
+    Ss_ztf,
+    Dataquality,
+    Ps1_ztf,
+)
 
 
 class PSQLConnection:

--- a/metadata_step/metadata_step/utils/legacy_models.py
+++ b/metadata_step/metadata_step/utils/legacy_models.py
@@ -1,0 +1,152 @@
+"""Legacy ZTF crossmatch ORM models, vendored for metadata_step.
+
+These five models (`reference`, `ss_ztf`, `ps1_ztf`, `dataquality`, `gaia_ztf`)
+used to live in `db_plugins.db.sql.models`, but pipeline commit 09587bc rewrote
+`libs/db-plugins` into the unified multi-survey schema, renaming them
+(`ztf_reference`, `ztf_ss`, `ztf_ps1`, `ztf_dataquality`) and remapping them to
+different tables. metadata_step is the only step that still writes the original
+legacy tables (which are what the AWS-legacy and on-prem/quimal databases
+physically have), so the definitions are pinned here verbatim from db-plugins at
+09587bc~1 (version 27.5.7a25) to decouple this step from the rewritten lib.
+
+Definitions are copied exactly except that the foreign keys to the `object` and
+`detection` tables are dropped. They are never used here (no DDL, no
+relationships, no joins; metadata_step only does select-by-oid and
+insert-with-on_conflict against pre-existing tables), and keeping them as string
+refs makes SQLAlchemy try to resolve `object`/`detection` in this standalone
+MetaData during the ORM bulk-insert table-sort, raising NoReferencedTableError.
+The physical tables retain their FKs regardless.
+"""
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    BigInteger,
+    String,
+    Float,
+    Boolean,
+    Index,
+)
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Dataquality(Base):
+    __tablename__ = "dataquality"
+
+    candid = Column(BigInteger, primary_key=True)
+    oid = Column(String, primary_key=True)
+    fid = Column(Integer, nullable=False)
+    xpos = Column(Float)
+    ypos = Column(Float)
+    chipsf = Column(Float)
+    sky = Column(Float)
+    fwhm = Column(Float)
+    classtar = Column(Float)
+    mindtoedge = Column(Float)
+    seeratio = Column(Float)
+    aimage = Column(Float)
+    bimage = Column(Float)
+    aimagerat = Column(Float)
+    bimagerat = Column(Float)
+    nneg = Column(Integer)
+    nbad = Column(Integer)
+    sumrat = Column(Float)
+    scorr = Column(Float)
+    dsnrms = Column(Float)
+    ssnrms = Column(Float)
+    magzpsci = Column(Float)
+    magzpsciunc = Column(Float)
+    magzpscirms = Column(Float)
+    nmatches = Column(Integer)
+    clrcoeff = Column(Float)
+    clrcounc = Column(Float)
+    zpclrcov = Column(Float)
+    zpmed = Column(Float)
+    clrmed = Column(Float)
+    clrrms = Column(Float)
+    exptime = Column(Float)
+
+
+class Gaia_ztf(Base):
+    __tablename__ = "gaia_ztf"
+
+    oid = Column(String, primary_key=True)
+    candid = Column(BigInteger, nullable=False)
+    neargaia = Column(Float)
+    neargaiabright = Column(Float)
+    maggaia = Column(Float)
+    maggaiabright = Column(Float)
+    unique1 = Column(Boolean, nullable=False)
+
+
+class Ss_ztf(Base):
+    __tablename__ = "ss_ztf"
+
+    oid = Column(String, primary_key=True)
+    candid = Column(BigInteger, nullable=False)
+    ssdistnr = Column(Float)
+    ssmagnr = Column(Float)
+    ssnamenr = Column(String)
+
+    __table_args__ = (
+        Index("ix_ss_ztf_candid", "candid", postgresql_using="btree"),
+        Index("ix_ss_ztf_ssnamenr", "ssnamenr", postgresql_using="btree"),
+    )
+
+
+class Ps1_ztf(Base):
+    __tablename__ = "ps1_ztf"
+
+    oid = Column(String, primary_key=True)
+    candid = Column(BigInteger, primary_key=True)
+    objectidps1 = Column(Float)
+    sgmag1 = Column(Float)
+    srmag1 = Column(Float)
+    simag1 = Column(Float)
+    szmag1 = Column(Float)
+    sgscore1 = Column(Float)
+    distpsnr1 = Column(Float)
+    objectidps2 = Column(Float)
+    sgmag2 = Column(Float)
+    srmag2 = Column(Float)
+    simag2 = Column(Float)
+    szmag2 = Column(Float)
+    sgscore2 = Column(Float)
+    distpsnr2 = Column(Float)
+    objectidps3 = Column(Float)
+    sgmag3 = Column(Float)
+    srmag3 = Column(Float)
+    simag3 = Column(Float)
+    szmag3 = Column(Float)
+    sgscore3 = Column(Float)
+    distpsnr3 = Column(Float)
+    nmtchps = Column(Integer, nullable=False)
+    unique1 = Column(Boolean, nullable=False)
+    unique2 = Column(Boolean, nullable=False)
+    unique3 = Column(Boolean, nullable=False)
+
+
+class Reference(Base):
+    __tablename__ = "reference"
+
+    oid = Column(String, primary_key=True)
+    rfid = Column(BigInteger, primary_key=True)
+    candid = Column(BigInteger, nullable=False)
+    fid = Column(Integer, nullable=False)
+    rcid = Column(Integer)
+    field = Column(Integer)
+    magnr = Column(Float)
+    sigmagnr = Column(Float)
+    chinr = Column(Float)
+    sharpnr = Column(Float)
+    ranr = Column(Float(precision=53), nullable=False)
+    decnr = Column(Float(precision=53), nullable=False)
+    mjdstartref = Column(Float(precision=53), nullable=False)
+    mjdendref = Column(Float(precision=53), nullable=False)
+    nframesref = Column(Integer, nullable=False)
+
+    __table_args__ = (Index("ix_reference_fid", "fid", postgresql_using="btree"),)

--- a/metadata_step/poetry.lock
+++ b/metadata_step/poetry.lock
@@ -660,6 +660,7 @@ description = "Expand standard functools to methods"
 optional = false
 python-versions = "*"
 files = [
+    {file = "methodtools-0.4.7-py2.py3-none-any.whl", hash = "sha256:5e188c780b236adc12e75b5f078c5afb419ef99eb648569fc6d7071f053a1f11"},
     {file = "methodtools-0.4.7.tar.gz", hash = "sha256:e213439dd64cfe60213f7015da6efe5dd4003fd89376db3baa09fe13ec2bb0ba"},
 ]
 
@@ -1322,6 +1323,7 @@ description = "'Turn functions and methods into fully controllable objects'"
 optional = false
 python-versions = "*"
 files = [
+    {file = "wirerope-0.4.7-py2.py3-none-any.whl", hash = "sha256:332973a3be6898f02fd0e73b2e20414c5102cc6c811d75856a938206677495c8"},
     {file = "wirerope-0.4.7.tar.gz", hash = "sha256:f3961039218276283c5037da0fa164619def0327595f10892d562a61a8603990"},
 ]
 

--- a/metadata_step/pyproject.toml
+++ b/metadata_step/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metadata-step"
-version = "27.5.7a37"
+version = "27.5.7a40"
 description = ""
 authors = ["Pedro Gallardo <pedrogallardorobinson@gmail.com>"]
 readme = "README.md"

--- a/metadata_step/scripts/run_step.py
+++ b/metadata_step/scripts/run_step.py
@@ -27,7 +27,15 @@ from metadata_step import MetadataStep
 from metadata_step.utils.database import PSQLConnection
 
 
-DATABASE = get_credentials(STEP_CONFIG["DATABASE_SECRET_NAME"])
+# DB credentials. Cloud (AWS legacy): a Secrets Manager secret name resolves the
+# full connection. On-prem (quimal): no Secrets Manager access, so the non-sensitive
+# connection fields come from the mounted config.yaml (STEP_CONFIG["PSQL_CONFIG"]) and
+# only the password is injected from a Kubernetes Secret via the PSQL_PASSWORD env var.
+if STEP_CONFIG.get("DATABASE_SECRET_NAME"):
+    DATABASE = get_credentials(STEP_CONFIG["DATABASE_SECRET_NAME"])
+else:
+    DATABASE = dict(STEP_CONFIG["PSQL_CONFIG"])
+    DATABASE["PASSWORD"] = os.environ["PSQL_PASSWORD"]
 sql = PSQLConnection(DATABASE, echo=STEP_CONFIG.get("LOGGING_DEBUG", False))
 
 step = MetadataStep(config=STEP_CONFIG, db_sql=sql)

--- a/metadata_step/tests/unittests/test_format_detection.py
+++ b/metadata_step/tests/unittests/test_format_detection.py
@@ -1,0 +1,34 @@
+from unittest import mock
+
+from metadata_step.step import MetadataStep
+
+
+def _make_step():
+    # No real consumer/DB needed: _format_detection never touches self.db, and
+    # an empty catalog skips the gaia/ps1 catalog-update branches.
+    config = {"CONSUMER_CONFIG": {"CLASS": "unittest.mock.MagicMock"}}
+    return MetadataStep(config, db_sql=mock.MagicMock())
+
+
+def _message(band):
+    return {
+        "oid": "ZTFband",
+        "candid": 1,
+        "fid": band,
+        "extra_fields": {
+            # jdstartref/jdendref are read directly by format_reference
+            "jdstartref": 2455500.5,
+            "jdendref": 2455600.5,
+        },
+    }
+
+
+def test_format_detection_maps_all_ztf_bands():
+    # ZTF has three bands; the char fid is mapped to its numeric id. An i-band
+    # alert (fid='i') used to raise KeyError and poison-pill the consumer.
+    step = _make_step()
+    empty_catalogs = {"ps1": {}, "gaia": {}}
+    for band, expected in (("g", 1), ("r", 2), ("i", 3)):
+        out = step._format_detection(_message(band), empty_catalogs)
+        assert out["reference"]["fid"] == expected
+        assert out["dataquality"]["fid"] == expected


### PR DESCRIPTION
## Summary

`metadata_step` — the ZTF-legacy step that consumes `sorting-hat` and writes the
crossmatch metadata tables (`reference`, `ss_ztf`, `ps1_ztf`, `dataquality`,
`gaia_ztf`) directly to PSQL via on-conflict upsert (not through scribe) — was
**broken by the multi-survey work on this branch** and additionally crash-looped
on i-band alerts. This PR fixes both so the step runs again against the
multi-survey codebase, and adds the CI plumbing needed to publish the on-prem
image variant.

Two independent breakages are addressed:

1. **Import broke on `multisurvey`.** Commit `09587bc` rewrote `libs/db-plugins`
   into the unified multi-survey schema, renaming/remapping the five legacy ZTF
   crossmatch models (`reference→ztf_reference`, `ss_ztf→ztf_ss`, `ps1_ztf→ztf_ps1`,
   `dataquality→ztf_dataquality`, …). `metadata_step` is the only step that still
   writes the *original* legacy tables (which is what both the AWS-legacy and the
   on-prem/quimal databases physically have), so it was orphaned — it couldn't
   import its models any more.
2. **i-band poison-pill.** The `fid` map was `{"g": 1, "r": 2}`, so any i-band
   alert raised `KeyError: 'i'` and crash-looped the consumer on its uncommitted
   batch.

## Changes

### metadata_step (bump `27.5.7a37` → `27.5.7a40`)
- **`step.py`** — add i-band to the FID map (`{"g": 1, "r": 2, "i": 3}`); fixes the
  `KeyError: 'i'` poison-pill.
- **`utils/legacy_models.py`** *(new)* — vendor the five legacy ZTF crossmatch ORM
  models verbatim from db-plugins `27.5.7a25` (`09587bc~1`), with a self-contained
  `Base`, decoupling the step from the rewritten lib. FKs to `object`/`detection`
  are **dropped in the ORM definitions only** — they made SQLAlchemy's bulk-insert
  table-sort resolve `object`/`detection` in this standalone `MetaData` and raise
  `NoReferencedTableError`. The step does no DDL/joins/relationships (only
  select-by-oid + insert-on-conflict against pre-existing tables), and the
  **physical tables keep their FKs**.
- **`utils/database.py`** — import the five models from `utils.legacy_models`.
- **`scripts/run_step.py`** — DB-credentials fallback: when `DATABASE_SECRET_NAME`
  is unset (on-prem/quimal, where AWS Secrets Manager is unavailable), read the
  non-sensitive connection fields from `PSQL_CONFIG` (mounted `config.yaml`) and the
  password from the `PSQL_PASSWORD` env var (k8s Secret). **Cloud path unchanged.**
- **`poetry.lock`** — add the universal-wheel hashes for `methodtools`/`wirerope`
  0.4.7 (the lock had sdist-only; `wirerope`'s sdist imports `pkg_resources` and
  fails under modern setuptools). **Content-hash unchanged — not a re-lock.**
- **Test** — add a DB-free unit test asserting `_format_detection` maps all three
  ZTF bands (g/r/i), guarding the poison-pill regression.

### CI / build
- **`ci/cli_build.py`, `ci/build.py`, `ci/utils.py`** — thread an optional `--tag`
  through `build direct` to override the version-derived tags (`["rc", <version>]`)
  with one explicit tag, so an overlay image publishes **without clobbering** the
  canonical `:rc` / `:<version>`.
- **`ci/cli_build.py`** — guard `for a in build_args or []` so `direct` works without
  `--build-args`, and harden the build-arg split to `split(":", 1)` for
  colon-bearing values.
- **`metadata_step/Dockerfile`** — add a default-off `CONFLUENT_KAFKA_VERSION`
  build-arg that pip-upgrades `confluent-kafka` in the venv (no-op when empty), for
  the quimal SCRAM-SHA-512 broker (librdkafka 2.0.2 SCRAM bug). Image-layer overlay,
  **not a poetry re-lock** (re-locking conflicts with apf multisurvey).
- **`PIPELINE.md`** — update the `metadata_step` entry (consumes `sorting-hat`;
  writes the five crossmatch tables directly via upsert; no Kafka data output).

## Testing
- New DB-free unit test (`test_format_detection.py`) covers g/r/i band mapping.
- The `27.5.7a40` image (with the cfk overlay) has been **running on quimal since
  20/06/2026** against the real legacy tables, and the AWS-legacy `metadata_step`
  runs the same patch — so this code is proven in production on both.

## Follow-up (separate PR)
`metadata_step` has a *second*, unrelated crash cause still open: a
`dataquality → detection` FK orphan from a scribe bug that silently drops
detections whose `parent_candid` is the string `"nan"`. That fix lands separately
in `scribe/mongo_scribe/` and is **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)