### PR TITLE
Fix silent detection loss in scribe SQL path (parent_candid="nan") + restore legacy db-plugins models

### DIFF
--- a/MONGODB-LEGACY.md
+++ b/MONGODB-LEGACY.md
@@ -1,0 +1,111 @@
+# MongoDB in this repo is a retired backend
+
+**TL;DR.** MongoDB was ALeRCE's *original* multi-survey storage attempt. It was
+abandoned in favour of PostgreSQL (the schema the current multisurvey pipeline
+uses). **No MongoDB instance runs anywhere today** — not for the legacy ZTF
+pipeline, not for the multisurvey one. The Mongo code that is still scattered
+through this repo is **dead weight left in place on purpose**: the legacy
+pipeline is being retired, so removing it isn't worth the churn. This document
+exists so you don't mistake the fossils for a live system.
+
+Last reviewed: 03/07/2026.
+
+---
+
+## Why you'll see "mongo" everywhere
+
+A case-insensitive search for `mongo` hits ~30 source/config/doc files (plus a
+lot of `pymongo` wheel hashes in `poetry.lock`s). The meaningful ones:
+
+| Area | What it is | Status |
+|---|---|---|
+| `libs/db-plugins/db_plugins/db/mongo/` | Full Mongo ORM: `_connection.py`, `models.py`, `orm.py`, `initialization.py`, `helpers/` | Unused at runtime |
+| `scribe/` (the package is literally `mongo_scribe`, class `MongoScribe`) | The scribe supports **both** a Mongo and a SQL backend, chosen at runtime | Only the **SQL** path is deployed |
+| `scribe/mongo_scribe/mongo/` | The Mongo half of the scribe (command decode + executor) | Unused at runtime |
+| `lightcurve-step` | Parallel `database_mongo.py`/`parser_mongo.py` **and** `database_sql.py`/`parser_sql.py`, toggled by `USE_MONGO`/`USE_SQL` | Mongo path off |
+| `sorting_hat_step` | `MongoConnection` + `MONGO_CONFIG` (Mongo once held the cross-survey `aid` identity) | Postgres (`ENGINE: "postgres"`) |
+| `correction_multisurvey_step` | Still declares `pymongo` + references it in `credentials.py` | Vestigial |
+| `pymongo` / `mongomock` deps | Pinned in `db-plugins`, `test_utils`, `sorting_hat`, `lightcurve`, `correction_multisurvey` | Installed, mostly for tests |
+| `tests/**/docker-compose.*`, `.github/workflows/*` | Integration tests spin up a **throwaway** Mongo container | The only place a real Mongo actually starts |
+
+The naming is a fossil: `mongo_scribe`/`MongoScribe` predate the SQL backend and
+were never renamed.
+
+## How Mongo is gated off
+
+Nothing needs Mongo removed because every deployment simply doesn't select it:
+
+- **scribe** — `DB_TYPE = os.getenv("DB_ENGINE", "mongo")` (`scribe/settings.py`)
+  *defaults* to mongo, but the deployed config sets `DB_ENGINE=sql`, and
+  `scribe/scripts/run_step.py` then builds `MongoScribe(..., db="sql")`, wiring
+  the `sql/` command factory + `SQLCommandExecutor`.
+- **lightcurve / sorting_hat** — the Helm charts set `MONGO_SECRET_NAME: ""`, so
+  no Mongo credentials are provided and the Mongo code paths are inert.
+
+## The consequence that actually bites: dual-dialect scribe commands
+
+This is the reason this doc exists. ALeRCE's scribe layer is a **CQRS-style
+writer** with two command *dialects*, one per historical backend:
+
+- **Mongo dialect** — generic document ops keyed on `type`
+  (`insert` / `update` / `update_probabilities` / `update_features`), any
+  `collection`. Decoded by `scribe/mongo_scribe/mongo/command/decode.py`.
+- **SQL dialect** — typed, relational ops matched on `(type, collection)`
+  pairs. Decoded by `scribe/mongo_scribe/sql/command/decode.py`.
+
+Some producers still emit **both dialects for the same write**, so the step
+could feed either backend. The clearest case is **`magstats_step`**
+([`magstats_step/step.py`](magstats_step/magstats_step/step.py)): its
+`post_execute` calls `produce_scribe()` **and** `produce_scribe_ztf()`, sending
+two commands per object built from the *same* stats dict:
+
+```
+produce_scribe      → {"type":"update",  "collection":"object"}   # Mongo dialect
+produce_scribe_ztf  → {"type":"upsert",  "collection":"magstats"} # SQL dialect
+```
+
+The SQL scribe (`scribe-psql`, the only one deployed on quimal) consumes the
+`upsert`/`magstats` command — `UpdateObjectStatsCommand` writes the object
+aggregates to the `object` table **and** upserts the per-band `magstats` rows.
+The `update`/`object` command is the **Mongo dialect**: it has no SQL handler,
+and with no Mongo backend to consume it, it is an **orphan** — produced, then
+dropped by the only scribe reading the topic. **No data is lost**: the identical
+statistics land via the SQL command.
+
+Historically this orphan was logged (at DEBUG) as
+`Unrecognized command type update in table object.` and counted in the
+`Found N invalid messages` INFO summary. That counter therefore **conflated** two
+very different things: these frequent, benign Mongo-dialect orphans, and genuine
+dropped commands (e.g. the `parent_candid="nan"` detection drop). If you're using
+`Found N invalid` to size real data loss, subtract the Mongo-dialect skips first.
+
+## What we did about it (and what we deliberately did not)
+
+- **Did not** remove the Mongo deadweight — the legacy pipeline is retiring, so
+  it isn't worth the churn.
+- **Did** teach the SQL decoder to recognise the Mongo-dialect object update
+  explicitly and skip it *quietly*:
+  - `sql/command/decode.py` raises the dedicated
+    `MongoDialectCommandException` (subclass of `ValueError`) for a
+    `{"type":"update","collection":"object"}` command with no `xmatch`.
+  - `scribe/mongo_scribe/step.py` catches that **before** the generic
+    `except ValueError`, counts it separately, and reports it as
+    `Skipped N legacy Mongo-dialect commands` instead of WARN-logging each with
+    its full payload.
+  - Why this matters now: a companion fix raised the previously-silent
+    invalid-command drop from DEBUG to **WARN + payload** (so real losses like
+    the `nan` detection stop vanishing silently). Without this skip, the
+    per-object magstats orphan would **flood** that WARN channel and bury the
+    signal it was added to surface.
+
+If a future SQL-relevant object update is ever needed, give it a **distinct
+type** (e.g. the existing `update_object_from_stats`) rather than reusing the
+generic Mongo `update`/`object` shape.
+
+## See also
+
+- `scribe/README.md` — scribe command format (Mongo-centric; the SQL dialect is
+  the `sql/command/` decoder).
+- Detection-loss / `parent_candid="nan"` investigation (aws_cost_analysis repo,
+  `docs/detection-loss-debug-plan.md`) — where the `Found N invalid` counter
+  reconciliation was traced.

--- a/charts/scribe/Chart.yaml
+++ b/charts/scribe/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 27.5.7-37
+version: 27.5.7-38
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 27.5.7a37
+appVersion: 27.5.7a38

--- a/charts/scribe/Chart.yaml
+++ b/charts/scribe/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 27.5.7-38
+version: 27.5.7-39
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 27.5.7a38
+appVersion: 27.5.7a39

--- a/libs/db-plugins/db_plugins/db/sql/models.py
+++ b/libs/db-plugins/db_plugins/db/sql/models.py
@@ -1,16 +1,19 @@
 from sqlalchemy import (
-    TIMESTAMP,
-    VARCHAR,
-    BigInteger,
-    Boolean,
     Column,
-    ForeignKeyConstraint,
-    Index,
     Integer,
-    PrimaryKeyConstraint,
-    SmallInteger,
+    BigInteger,
+    String,
+    ForeignKey,
+    Float,
+    Boolean,
+    ARRAY,
+    Index,
+    UniqueConstraint,
+    DateTime,
+    JSON,
+    ForeignKeyConstraint,
 )
-from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, REAL
+
 from sqlalchemy.orm import DeclarativeBase
 
 
@@ -23,454 +26,466 @@ class Commons:
         return self.__dict__[field]
 
 
+class Step(Base):
+    __tablename__ = "step"
+
+    step_id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    version = Column(String, nullable=False)
+    comments = Column(String, nullable=False)
+    date = Column(DateTime, nullable=False)
+
+
 class Object(Base):
     __tablename__ = "object"
 
-    oid = Column(BigInteger, nullable=False)
-    tid = Column(SmallInteger, nullable=False)
-    sid = Column(SmallInteger, nullable=False)
-    meanra = Column(DOUBLE_PRECISION, nullable=False)
-    meandec = Column(DOUBLE_PRECISION, nullable=False)
-    sigmara = Column(DOUBLE_PRECISION, nullable=True)
-    sigmadec = Column(DOUBLE_PRECISION, nullable=True)
-    firstmjd = Column(DOUBLE_PRECISION, nullable=False)
-    lastmjd = Column(DOUBLE_PRECISION, nullable=False)
-    deltamjd = Column(DOUBLE_PRECISION, nullable=False, default=0.0)
-    n_det = Column(Integer, nullable=False, default=1)
-    n_forced = Column(Integer, nullable=False, default=1)
-    n_non_det = Column(Integer, nullable=False, default=1)
+    oid = Column(String, primary_key=True)
+    ndethist = Column(Integer, nullable=False)
+    ncovhist = Column(Integer, nullable=False)
+    mjdstarthist = Column(Float(precision=53))
+    mjdendhist = Column(Float(precision=53))
     corrected = Column(Boolean, nullable=False, default=False)
-    stellar = Column(Boolean, nullable=True)
+    stellar = Column(Boolean, nullable=False, default=False)
+    ndet = Column(Integer, nullable=False, default=1)
+    g_r_max = Column(Float)
+    g_r_max_corr = Column(Float)
+    g_r_mean = Column(Float)
+    g_r_mean_corr = Column(Float)
+    meanra = Column(Float(precision=53), nullable=False)
+    meandec = Column(Float(precision=53), nullable=False)
+    sigmara = Column(Float(precision=53))
+    sigmadec = Column(Float(precision=53))
+    deltajd = Column(Float(precision=53), nullable=False)
+    firstmjd = Column(Float(precision=53), nullable=False)
+    lastmjd = Column(Float(precision=53), nullable=False)
+    step_id_corr = Column(String, nullable=False)
+    diffpos = Column(Boolean)
+    reference_change = Column(Boolean)
 
     __table_args__ = (
-        PrimaryKeyConstraint("oid", "sid", name="pk_object_oid_sid"),
-        Index("ix_object_n_det", "n_det", postgresql_using="btree"),
+        Index("ix_object_ndet", "ndet", postgresql_using="btree"),
         Index("ix_object_firstmjd", "firstmjd", postgresql_using="btree"),
-        Index("ix_object_lastmjd", "lastmjd", postgresql_using="btree"),
+        Index("ix_object_g_r_max", "g_r_max", postgresql_using="btree"),
+        Index("ix_object_g_r_mean_corr", "g_r_mean_corr", postgresql_using="btree"),
         Index("ix_object_meanra", "meanra", postgresql_using="btree"),
         Index("ix_object_meandec", "meandec", postgresql_using="btree"),
     )
 
-
-class ZtfObject(Base):
-    __tablename__ = "ztf_object"
-
-    oid = Column(BigInteger, nullable=False)
-    g_r_max = Column(REAL)
-    g_r_max_corr = Column(REAL)
-    g_r_mean = Column(REAL)
-    g_r_mean_corr = Column(REAL)
-
-    __table_args__ = (PrimaryKeyConstraint("oid", name="pk_ztfobject_oid"),)
+    def __repr__(self):
+        return "<Object(oid='%s')>" % (self.oid)
 
 
-class LsstDiaObject(Base):
-    __tablename__ = "lsst_dia_object"
-
-    oid = Column(BigInteger, nullable=False)
-
-    __table_args__ = (PrimaryKeyConstraint("oid", name="pk_lsstdiaobject_oid"),)
-
-
-class LsstSsObject(Base):
-    __tablename__ = "lsst_ss_object"
-
-    oid = Column(BigInteger, nullable=False)
-
-    __table_args__ = (PrimaryKeyConstraint("oid", name="pk_lsstssobject_oid"),)
+class Taxonomy(Base):
+    __tablename__ = "taxonomy"
+    classifier_name = Column(String, primary_key=True)
+    classifier_version = Column(String, primary_key=True)
+    classes = Column(ARRAY(String), nullable=False)
 
 
-class Detection(Base):
-    __tablename__ = "detection"
-
-    oid = Column(BigInteger, nullable=False)  # int8,
-    sid = Column(SmallInteger, nullable=False)
-    measurement_id = Column(BigInteger, nullable=False)  # int8,
-    mjd = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    ra = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    dec = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    band = Column(SmallInteger, nullable=False)  # int2,
+class Probability(Base):
+    __tablename__ = "probability"
+    oid = Column(String, ForeignKey(Object.oid), primary_key=True)
+    class_name = Column(String, primary_key=True)
+    classifier_name = Column(String, primary_key=True)
+    classifier_version = Column(String, primary_key=True)
+    probability = Column(Float, nullable=False)
+    ranking = Column(Integer, nullable=False)
 
     __table_args__ = (
-        PrimaryKeyConstraint(
-            "oid", "measurement_id", name="pk_detection_oid_measurementid"
-        ),
-        ForeignKeyConstraint([oid, sid], [Object.oid, Object.sid]),
-        Index("ix_detection_oid", "oid", postgresql_using="hash"),
-    )
-
-
-class ZtfDetection(Base):
-    __tablename__ = "ztf_detection"
-
-    oid = Column(BigInteger, nullable=False)  # int8,
-    sid = Column(SmallInteger, nullable=False)
-    measurement_id = Column(BigInteger, nullable=False)  # int8,
-    pid = Column(BigInteger)  # int8,
-    diffmaglim = Column(REAL)  # float4,
-    isdiffpos = Column(Integer)  # bool,
-    nid = Column(Integer)  # int4,
-    magpsf = Column(REAL)  # float4,
-    sigmapsf = Column(REAL)  # float4,
-    magap = Column(REAL)  # float4,
-    sigmagap = Column(REAL)  # float4,
-    distnr = Column(REAL)  # float4,
-    rb = Column(REAL)  # float4,
-    rbversion = Column(VARCHAR)  # varchar,
-    drb = Column(REAL)  # float4,
-    drbversion = Column(VARCHAR)  # varchar,
-    magapbig = Column(REAL)  # float4,
-    sigmagapbig = Column(REAL)  # float4,
-    rfid = Column(BigInteger)  # int8,
-    magpsf_corr = Column(Integer)  # float4,
-    sigmapsf_corr = Column(Integer)  # float4,
-    sigmapsf_corr_ext = Column(Integer)  # float4,
-    corrected = Column(Boolean)  # bool,
-    dubious = Column(Boolean)  # bool,
-    parent_candid = Column(BigInteger)  # int8,
-    has_stamp = Column(Boolean)  # bool,
-
-    __table_args__ = (
-        PrimaryKeyConstraint(
-            "oid", "measurement_id", name="pk_ztfdetection_oid_measurementid"
-        ),
-        ForeignKeyConstraint([oid, sid], [Object.oid, Object.sid]),
-        Index("ix_ztfdetection_oid", "oid", postgresql_using="hash"),
-    )
-
-
-class LsstDetection(Base):
-    __tablename__ = "lsst_detection"
-
-    oid = Column(BigInteger, nullable=False)  # int8,
-    sid = Column(SmallInteger, nullable=False)
-    measurement_id = Column(BigInteger, nullable=False)  # int8,
-    parentDiaSourceId = Column(BigInteger)
-
-    psfFlux = Column(REAL)
-    psfFluxErr = Column(REAL)
-
-    psfFlux_flag = Column(Boolean)
-    psfFlux_flag_edge = Column(Boolean)
-    psfFlux_flag_noGoodPixels = Column(Boolean)
-
-    __table_args__ = (
-        PrimaryKeyConstraint(
-            "oid", "measurement_id", name="pk_lsstdetection_oid_measurementid"
-        ),
-        ForeignKeyConstraint([oid, sid], [Object.oid, Object.sid]),
-        Index("ix_lsstdetection_oid", "oid", postgresql_using="hash"),
-    )
-
-
-class ForcedPhotometry(Base):
-    __tablename__ = "forced_photometry"
-
-    oid = Column(BigInteger, nullable=False)  # int8,
-    sid = Column(SmallInteger, nullable=False)
-    measurement_id = Column(BigInteger, nullable=False)  # int8,
-    mjd = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    ra = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    dec = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    band = Column(SmallInteger, nullable=False)  # int2,
-
-    __table_args__ = (
-        PrimaryKeyConstraint(
-            "oid", "measurement_id", name="pk_forcedphotometry_oid_measurementid"
-        ),
-        ForeignKeyConstraint([oid, sid], [Object.oid, Object.sid]),
-        Index("ix_forced_photometry_oid", "oid", postgresql_using="hash"),
-    )
-
-
-class ZtfForcedPhotometry(Base):
-    __tablename__ = "ztf_forced_photometry"
-
-    oid = Column(BigInteger, nullable=False)  # int8,
-    sid = Column(SmallInteger, nullable=False)
-    measurement_id = Column(BigInteger, nullable=False)  # int8,
-    pid = Column(BigInteger)  # int8
-    mag = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    e_mag = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    mag_corr = Column(DOUBLE_PRECISION)  # float8,
-    e_mag_corr = Column(DOUBLE_PRECISION)  # float8,
-    e_mag_corr_ext = Column(DOUBLE_PRECISION)  # float8,
-    isdiffpos = Column(Integer, nullable=False)  # int4 NOT NULL,
-    corrected = Column(Boolean, nullable=False)  # bool NOT NULL,
-    dubious = Column(Boolean, nullable=False)  # bool NOT NULL,
-    parent_candid = Column(BigInteger)  # varchar,
-    has_stamp = Column(Boolean, nullable=False)  # bool NOT NULL,
-    field = Column(Integer, nullable=False)  # int4,
-    rcid = Column(Integer, nullable=False)  # int4,
-    rfid = Column(BigInteger, nullable=False)  # int8,
-    sciinpseeing = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    scibckgnd = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    scisigpix = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    magzpsci = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    magzpsciunc = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    magzpscirms = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    clrcoeff = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    clrcounc = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    exptime = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    adpctdif1 = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    adpctdif2 = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    diffmaglim = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    programid = Column(Integer, nullable=False)  # int4,
-    procstatus = Column(VARCHAR, nullable=False)  # varchar,
-    distnr = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    ranr = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    decnr = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    magnr = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    sigmagnr = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    chinr = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    sharpnr = Column(DOUBLE_PRECISION, nullable=False)  # float8
-
-    __table_args__ = (
-        PrimaryKeyConstraint(
-            "oid", "measurement_id", name="pk_ztfforcedphotometry_oid_measurementid"
-        ),
-        ForeignKeyConstraint([oid, sid], [Object.oid, Object.sid]),
-        Index("ix_ztf_forced_photometry_oid", "oid", postgresql_using="hash"),
-    )
-
-
-class LsstForcedPhotometry(Base):
-    __tablename__ = "lsst_forced_photometry"
-
-    oid = Column(BigInteger, nullable=False)  # int8,
-    measurement_id = Column(BigInteger, nullable=False)  # int8,
-    sid = Column(SmallInteger, nullable=False)
-
-    visit = Column(BigInteger, nullable=False)
-    detector = Column(Integer, nullable=False)
-
-    psfFlux = Column(REAL, nullable=False)
-    psfFluxErr = Column(REAL, nullable=False)
-
-    __table_args__ = (
-        PrimaryKeyConstraint(
-            "oid", "measurement_id", name="pk_lsstforcedphotometry_oid_measurementid"
-        ),
-        ForeignKeyConstraint([oid, sid], [Object.oid, Object.sid]),
-        Index("ix_lsst_forced_photometry_oid", "oid", postgresql_using="hash"),
-    )
-
-
-class NonDetection(Base):
-    __tablename__ = "non_detection"
-
-    oid = Column(BigInteger, nullable=False)  # int8,
-    sid = Column(SmallInteger, nullable=False)
-    band = Column(SmallInteger, nullable=False)  # int2,
-    mjd = Column(DOUBLE_PRECISION, nullable=False)  # float8,
-    diffmaglim = Column(REAL, nullable=False)  # float4,
-
-    __table_args__ = (
-        PrimaryKeyConstraint("oid", "mjd", name="pk_oid_mjd"),
-        ForeignKeyConstraint([oid, sid], [Object.oid, Object.sid]),
-        Index("ix_non_detection_oid", "oid", postgresql_using="hash"),
-    )
-
-
-class LsstNonDetection(Base):
-    __tablename__ = "lsst_non_detection"
-
-    oid = Column(BigInteger, nullable=False)  # int8,
-    sid = Column(SmallInteger, nullable=False)
-    ccdVisitId = Column(BigInteger, nullable=False)
-    band = Column(SmallInteger, nullable=False)
-    mjd = Column(DOUBLE_PRECISION, nullable=False)
-    diaNoise = Column(REAL, nullable=False)
-
-    __table_args__ = (
-        PrimaryKeyConstraint("oid", "mjd", name="pk_lsstnondetection_oid_mjd"),
-        ForeignKeyConstraint([oid, sid], [Object.oid, Object.sid]),
-        Index("ix_lsst_non_detection_oid", "oid", postgresql_using="hash"),
-    )
-
-
-class ztf_ss(Base):
-    __tablename__ = "ztf_ss"
-
-    oid = Column(BigInteger, nullable=False)
-    measurement_id = Column(BigInteger, nullable=False)
-    ssdistnr = Column(REAL)
-    ssmagnr = Column(REAL)
-    ssnamenr = Column(REAL)
-
-    __table_args__ = (
-        PrimaryKeyConstraint(
-            "oid", "measurement_id", name="pk_ztfss_oid_measurement_id"
-        ),
-        Index("ix_zrt_ss_oid", "oid", postgresql_using="btree"),
-    )
-
-
-class ztf_ps1(Base):
-    __tablename__ = "ztf_ps1"
-
-    oid = Column(BigInteger, nullable=False)
-    measurement_id = Column(BigInteger, nullable=False)
-    objectidps1 = Column(BigInteger)
-    sgmag1 = Column(REAL)
-    srmag1 = Column(REAL)
-    simag1 = Column(REAL)
-    szmag1 = Column(REAL)
-    sgscore1 = Column(REAL)
-    distpsnr1 = Column(REAL)
-    objectidps2 = Column(BigInteger)
-    sgmag2 = Column(REAL)
-    srmag2 = Column(REAL)
-    simag2 = Column(REAL)
-    szmag2 = Column(REAL)
-    sgscore2 = Column(REAL)
-    distpsnr2 = Column(REAL)
-    objectidps3 = Column(BigInteger)
-    sgmag3 = Column(REAL)
-    srmag3 = Column(REAL)
-    simag3 = Column(REAL)
-    szmag3 = Column(REAL)
-    sgscore3 = Column(REAL)
-    distpsnr3 = Column(REAL)
-    nmtchps = Column(SmallInteger)
-
-    __table_args__ = (
-        PrimaryKeyConstraint(
-            "oid", "measurement_id", name="pk_ztfps1_oid_measurement_id"
-        ),
-        Index("ix_ztf_ps1_oid", "oid", postgresql_using="btree"),
-    )
-
-
-class gaia_ztf(Base):
-    __tablename__ = "ztf_gaia"
-
-    oid = Column(BigInteger, nullable=False)
-    measurement_id = Column(BigInteger, nullable=False)
-    neargaia = Column(REAL)
-    neargaiabright = Column(REAL)
-    maggaia = Column(REAL)
-    maggaiabright = Column(REAL)
-
-    __table_args__ = (PrimaryKeyConstraint("oid", name="pk_ztfgaia_oid"),)
-
-
-class ztf_dataquality(Base):
-    __tablename__ = "ztf_dataquality"
-
-    oid = Column(BigInteger, nullable=False)
-    measurement_id = Column(BigInteger, nullable=False)
-    xpos = Column(REAL)
-    ypos = Column(REAL)
-    chipsf = Column(REAL)
-    sky = Column(REAL)
-    fwhm = Column(REAL)
-    classtar = Column(REAL)
-    mindtoedge = Column(REAL)
-    seeratio = Column(REAL)
-    aimage = Column(REAL)
-    bimage = Column(REAL)
-    aimagerat = Column(REAL)
-    bimagerat = Column(REAL)
-    nneg = Column(REAL)
-    nbad = Column(REAL)
-    sumrat = Column(REAL)
-    scorr = Column(REAL)
-    dsnrms = Column(REAL)
-    ssnrms = Column(REAL)
-    magzpsci = Column(REAL)
-    magzpsciunc = Column(REAL)
-    magzpscirms = Column(REAL)
-    nmatches = Column(REAL)
-    clrcoeff = Column(REAL)
-    clrcounc = Column(REAL)
-    zpclrcov = Column(REAL)
-    zpmed = Column(REAL)
-    clrmed = Column(REAL)
-    clrrms = Column(REAL)
-    exptime = Column(REAL)
-
-    __table_args__ = (
-        PrimaryKeyConstraint(
-            "oid", "measurement_id", name="pk_ztfdataquality_oid_measurement_id"
-        ),
-        Index("ix_ztf_dataquality_oid", "oid", postgresql_using="btree"),
+        Index("ix_probabilities_oid", "oid", postgresql_using="hash"),
+        Index("ix_probabilities_probability", "probability", postgresql_using="btree"),
+        Index("ix_probabilities_ranking", "ranking", postgresql_using="btree"),
         Index(
-            "ix_ztf_dataquality_measurement_id",
-            "measurement_id",
+            "ix_classification_rank1",
+            "ranking",
+            postgresql_where=ranking == 1,
             postgresql_using="btree",
         ),
     )
 
 
-class ztf_reference(Base):
-    __tablename__ = "ztf_reference"
-
-    oid = Column(BigInteger, nullable=False)
-    rfid = Column(BigInteger, nullable=False)
-    measurement_ic = Column(BigInteger, nullable=False)
-    band = Column(Integer)
-    rcid = Column(Integer)
-    field = Column(Integer)
-    magnr = Column(REAL)
-    sigmagnr = Column(REAL)
-    chinr = Column(REAL)
-    sharpnr = Column(REAL)
-    ranr = Column(DOUBLE_PRECISION)
-    decnr = Column(DOUBLE_PRECISION)
-    mjdstartref = Column(DOUBLE_PRECISION)
-    mjdendref = Column(DOUBLE_PRECISION)
-    nframesref = Column(Integer)
-
+class Score(Base):
+    __tablename__ = "score"
+    oid = Column(String, ForeignKey(Object.oid), primary_key=True)
+    detector_name = Column(String, primary_key=True)
+    detector_version = Column(String, primary_key=True)
+    category_name = Column(String, primary_key=True)
+    score = Column(Float, nullable=False)
     __table_args__ = (
-        PrimaryKeyConstraint("oid", "rfid", name="pk_ztfreference_oid_rfid"),
-        Index("ix_ztf_reference_oid", "oid", postgresql_using="btree"),
+        Index("ix_scores_oid", "oid", postgresql_using="hash"),
+        Index("ix_scores_score", "score", postgresql_using="btree"),
     )
 
 
-class MagStat(Base):
+class ScoreDistribution(Base):
+    __tablename__ = "score_distribution"
+    detector_name = Column(String, primary_key=True)
+    distribution_version = Column(String, primary_key=True)
+    creation_date = Column(DateTime)
+    category_name = Column(String, primary_key=True)
+    distribution_name = Column(String, primary_key=True)
+    distribution_value = Column(Float, nullable=False)
+    __table_args__ = (
+        Index(
+            "ix_scoredistribution_distribution_name",
+            "distribution_name",
+            postgresql_using="hash",
+        ),
+        Index(
+            "ix_scoredistribution_category_name",
+            "category_name",
+            postgresql_using="hash",
+        ),
+        Index(
+            "ix_scoredistribution_detector_name",
+            "category_name",
+            postgresql_using="hash",
+        ),
+    )
+
+
+class FeatureVersion(Base):
+    __tablename__ = "feature_version"
+    version = Column(String, primary_key=True)
+    step_id_feature = Column(String, ForeignKey(Step.step_id))
+    step_id_preprocess = Column(String, ForeignKey(Step.step_id))
+
+    # __table_args__ = (ForeignKeyConstraint([step_id_feature, step_id_preprocess],
+    #                                        [Step.step_id, Step.step_id]),
+    #                   {})
+
+
+class Feature(Base):
+    __tablename__ = "feature"
+
+    oid = Column(String, ForeignKey("object.oid"), primary_key=True)
+    name = Column(String, primary_key=True, nullable=False)
+    value = Column(Float(precision=53))
+    fid = Column(Integer, primary_key=True)
+    version = Column(String, primary_key=True, nullable=False)
+
+    __table_args__ = (Index("ix_feature_oid_2", "oid", postgresql_using="hash"),)
+
+
+class Xmatch(Base):
+    __tablename__ = "xmatch"
+
+    oid = Column(String, ForeignKey("object.oid"), primary_key=True)
+    catid = Column(String, primary_key=True)
+    oid_catalog = Column(String, nullable=False)
+    dist = Column(Float(precision=53), nullable=False)
+    class_catalog = Column(String)
+    period = Column(Float(precision=53))
+
+
+class Allwise(Base):
+    __tablename__ = "allwise"
+
+    oid_catalog = Column(String, primary_key=True)
+    ra = Column(Float(precision=53), nullable=False)
+    dec = Column(Float(precision=53), nullable=False)
+    w1mpro = Column(Float(precision=53))
+    w2mpro = Column(Float(precision=53))
+    w3mpro = Column(Float(precision=53))
+    w4mpro = Column(Float(precision=53))
+    w1sigmpro = Column(Float(precision=53))
+    w2sigmpro = Column(Float(precision=53))
+    w3sigmpro = Column(Float(precision=53))
+    w4sigmpro = Column(Float(precision=53))
+    j_m_2mass = Column(Float(precision=53))
+    h_m_2mass = Column(Float(precision=53))
+    k_m_2mass = Column(Float(precision=53))
+    j_msig_2mass = Column(Float(precision=53))
+    h_msig_2mass = Column(Float(precision=53))
+    k_msig_2mass = Column(Float(precision=53))
+
+    __table_args__ = (
+        Index("ix_allwise_dec", "dec", postgresql_using="btree"),
+        Index("ix_allwise_ra", "ra", postgresql_using="btree"),
+    )
+
+
+class MagStats(Base):
     __tablename__ = "magstat"
 
-    oid = Column(BigInteger, nullable=False)  # int8
-    sid = Column(SmallInteger, nullable=False)
-    band = Column(SmallInteger, nullable=False)  # int2
-    stellar = Column(Boolean)  # bool
-    corrected = Column(Boolean)  # bool
-    ndubious = Column(BigInteger)  # int8
-    dmdt_first = Column(BigInteger)  # int8
-    dm_first = Column(BigInteger)  # int8
-    sigmadm_first = Column(BigInteger)  # int8
-    dt_first = Column(BigInteger)  # int8
-    magmean = Column(DOUBLE_PRECISION)  # float8
-    magmedian = Column(DOUBLE_PRECISION)  # float8
-    magmax = Column(DOUBLE_PRECISION)  # float8
-    magmin = Column(DOUBLE_PRECISION)  # float8
-    magsigma = Column(DOUBLE_PRECISION)  # float8
-    maglast = Column(BigInteger)  # int8
-    magfirst = Column(BigInteger)  # int8
-    magmean_corr = Column(DOUBLE_PRECISION)  # float8
-    magmedian_corr = Column(DOUBLE_PRECISION)  # float8
-    magmax_corr = Column(DOUBLE_PRECISION)  # float8
-    magmin_corr = Column(DOUBLE_PRECISION)  # float8
-    magsigma_corr = Column(DOUBLE_PRECISION)  # float8
-    maglast_corr = Column(DOUBLE_PRECISION)  # float8
-    magfirst_corr = Column(DOUBLE_PRECISION)  # float8
-    step_id_corr = Column(VARCHAR)  # varchar
-    saturation_rate = Column(DOUBLE_PRECISION)  # float8
-    last_update = Column(TIMESTAMP)  # timestamp
+    oid = Column(String, ForeignKey("object.oid"), primary_key=True)
+    fid = Column(Integer, primary_key=True)
+    stellar = Column(Boolean, nullable=False)
+    corrected = Column(Boolean, nullable=False)
+    ndet = Column(Integer, nullable=False)
+    ndubious = Column(Integer, nullable=False)
+    dmdt_first = Column(Float)
+    dm_first = Column(Float)
+    sigmadm_first = Column(Float)
+    dt_first = Column(Float)
+    magmean = Column(Float)
+    magmedian = Column(Float)
+    magmax = Column(Float)
+    magmin = Column(Float)
+    magsigma = Column(Float)
+    maglast = Column(Float)
+    magfirst = Column(Float)
+    magmean_corr = Column(Float)
+    magmedian_corr = Column(Float)
+    magmax_corr = Column(Float)
+    magmin_corr = Column(Float)
+    magsigma_corr = Column(Float)
+    maglast_corr = Column(Float)
+    magfirst_corr = Column(Float)
+    firstmjd = Column(Float(precision=53))
+    lastmjd = Column(Float(precision=53))
+    step_id_corr = Column(String, nullable=False)
+    saturation_rate = Column(Float(precision=53))
 
     __table_args__ = (
-        PrimaryKeyConstraint("oid", "band", name="pk_magstat_oid_band"),
-        ForeignKeyConstraint([oid, sid], [Object.oid, Object.sid]),
+        Index("ix_magstats_dmdt_first", "dmdt_first", postgresql_using="btree"),
+        Index("ix_magstats_firstmjd", "firstmjd", postgresql_using="btree"),
+        Index("ix_magstats_lastmjd", "lastmjd", postgresql_using="btree"),
+        Index("ix_magstats_magmean", "magmean", postgresql_using="btree"),
+        Index("ix_magstats_magmin", "magmin", postgresql_using="btree"),
+        Index("ix_magstats_magfirst", "magfirst", postgresql_using="btree"),
+        Index("ix_magstats_ndet", "ndet", postgresql_using="btree"),
+        Index("ix_magstats_maglast", "maglast", postgresql_using="btree"),
+        Index("ix_magstats_oid", "oid", postgresql_using="hash"),
     )
 
 
-class LsstIdMapper(Base):
-    __tablename__ = "lsst_idmapper"
+class NonDetection(Base, Commons):
+    __tablename__ = "non_detection"
 
-    lsst_id_serial = Column(BigInteger, autoincrement=True)
-    lsst_diaObjectId = Column(BigInteger)
+    oid = Column(String, ForeignKey("object.oid"), primary_key=True)
+    fid = Column(Integer, primary_key=True)
+    mjd = Column(Float(precision=53), primary_key=True)
+    diffmaglim = Column(Float)
+    __table_args__ = (Index("ix_non_detection_oid", "oid", postgresql_using="hash"),)
+
+
+class Detection(Base, Commons):
+    __tablename__ = "detection"
+
+    candid = Column(BigInteger, primary_key=True)
+    oid = Column(String, ForeignKey("object.oid"), primary_key=True)
+    mjd = Column(Float(precision=53), nullable=False)
+    fid = Column(Integer, nullable=False)
+    pid = Column(Float, nullable=False)
+    diffmaglim = Column(Float)
+    isdiffpos = Column(Integer, nullable=False)
+    nid = Column(Integer)
+    ra = Column(Float(precision=53), nullable=False)
+    dec = Column(Float(precision=53), nullable=False)
+    magpsf = Column(Float, nullable=False)
+    sigmapsf = Column(Float, nullable=False)
+    magap = Column(Float)
+    sigmagap = Column(Float)
+    distnr = Column(Float)
+    rb = Column(Float)
+    rbversion = Column(String)
+    drb = Column(Float)
+    drbversion = Column(String)
+    magapbig = Column(Float)
+    sigmagapbig = Column(Float)
+    rfid = Column(Integer)
+    magpsf_corr = Column(Float)
+    sigmapsf_corr = Column(Float)
+    sigmapsf_corr_ext = Column(Float)
+    corrected = Column(Boolean, nullable=False)
+    dubious = Column(Boolean, nullable=False)
+    parent_candid = Column(BigInteger)
+    has_stamp = Column(Boolean, nullable=False)
+    step_id_corr = Column(String, nullable=False)
+
+    __table_args__ = (Index("ix_ndetection_oid", "oid", postgresql_using="hash"),)
+
+    def __repr__(self):
+        return "<Detection(candid='%i', fid='%i', oid='%s')>" % (
+            self.candid,
+            self.fid,
+            self.oid,
+        )
+
+
+class ForcedPhotometry(Base):
+    __tablename__ = "forced_photometry"
+
+    pid = Column(BigInteger, primary_key=True)
+    oid = Column(String, primary_key=True)
+    mjd = Column(Float(precision=53), nullable=False)
+    fid = Column(Integer, nullable=False)
+    ra = Column(Float(precision=53), nullable=False)
+    dec = Column(Float(precision=53), nullable=False)
+    e_ra = Column(Float)
+    e_dec = Column(Float)
+    mag = Column(Float)
+    e_mag = Column(Float)
+    mag_corr = Column(Float)
+    e_mag_corr = Column(Float)
+    e_mag_corr_ext = Column(Float)
+    isdiffpos = Column(Integer, nullable=False)
+    corrected = Column(Boolean, nullable=False)
+    dubious = Column(Boolean, nullable=False)
+    parent_candid = Column(String)
+    has_stamp = Column(Boolean, nullable=False)
+    # extra fields
+    field = Column(Integer)
+    rcid = Column(Integer)
+    rfid = Column(BigInteger)
+    sciinpseeing = Column(Float)
+    scibckgnd = Column(Float)
+    scisigpix = Column(Float)
+    magzpsci = Column(Float)
+    magzpsciunc = Column(Float)
+    magzpscirms = Column(Float)
+    clrcoeff = Column(Float)
+    clrcounc = Column(Float)
+    exptime = Column(Float)
+    adpctdif1 = Column(Float)
+    adpctdif2 = Column(Float)
+    diffmaglim = Column(Float)
+    programid = Column(Integer)
+    procstatus = Column(String)
+    distnr = Column(Float)
+    ranr = Column(Float(precision=53))
+    decnr = Column(Float(precision=53))
+    magnr = Column(Float)
+    sigmagnr = Column(Float)
+    chinr = Column(Float)
+    sharpnr = Column(Float)
 
     __table_args__ = (
-        PrimaryKeyConstraint("lsst_id_serial", name="pk_lsst_idmapper_serial"),
+        Index("ix_forced_photometry_oid", "oid", postgresql_using="hash"),
     )
+
+
+class Dataquality(Base):
+    __tablename__ = "dataquality"
+
+    candid = Column(BigInteger, primary_key=True)
+    oid = Column(String, primary_key=True)
+    fid = Column(Integer, nullable=False)
+    xpos = Column(Float)
+    ypos = Column(Float)
+    chipsf = Column(Float)
+    sky = Column(Float)
+    fwhm = Column(Float)
+    classtar = Column(Float)
+    mindtoedge = Column(Float)
+    seeratio = Column(Float)
+    aimage = Column(Float)
+    bimage = Column(Float)
+    aimagerat = Column(Float)
+    bimagerat = Column(Float)
+    nneg = Column(Integer)
+    nbad = Column(Integer)
+    sumrat = Column(Float)
+    scorr = Column(Float)
+    dsnrms = Column(Float)
+    ssnrms = Column(Float)
+    magzpsci = Column(Float)
+    magzpsciunc = Column(Float)
+    magzpscirms = Column(Float)
+    nmatches = Column(Integer)
+    clrcoeff = Column(Float)
+    clrcounc = Column(Float)
+    zpclrcov = Column(Float)
+    zpmed = Column(Float)
+    clrmed = Column(Float)
+    clrrms = Column(Float)
+    exptime = Column(Float)
+
+    __table_args__ = (
+        ForeignKeyConstraint([candid, oid], [Detection.candid, Detection.oid]),
+        {},
+    )
+
+
+class Gaia_ztf(Base):
+    __tablename__ = "gaia_ztf"
+
+    oid = Column(String, ForeignKey("object.oid"), primary_key=True)
+    candid = Column(BigInteger, nullable=False)
+    neargaia = Column(Float)
+    neargaiabright = Column(Float)
+    maggaia = Column(Float)
+    maggaiabright = Column(Float)
+    unique1 = Column(Boolean, nullable=False)
+
+
+class Ss_ztf(Base):
+    __tablename__ = "ss_ztf"
+
+    oid = Column(String, ForeignKey("object.oid"), primary_key=True)
+    candid = Column(BigInteger, nullable=False)
+    ssdistnr = Column(Float)
+    ssmagnr = Column(Float)
+    ssnamenr = Column(String)
+
+    __table_args__ = (
+        Index("ix_ss_ztf_candid", "candid", postgresql_using="btree"),
+        Index("ix_ss_ztf_ssnamenr", "ssnamenr", postgresql_using="btree"),
+    )
+
+
+class Ps1_ztf(Base):
+    __tablename__ = "ps1_ztf"
+
+    oid = Column(String, ForeignKey("object.oid"), primary_key=True)
+    candid = Column(BigInteger, primary_key=True)
+    objectidps1 = Column(Float)
+    sgmag1 = Column(Float)
+    srmag1 = Column(Float)
+    simag1 = Column(Float)
+    szmag1 = Column(Float)
+    sgscore1 = Column(Float)
+    distpsnr1 = Column(Float)
+    objectidps2 = Column(Float)
+    sgmag2 = Column(Float)
+    srmag2 = Column(Float)
+    simag2 = Column(Float)
+    szmag2 = Column(Float)
+    sgscore2 = Column(Float)
+    distpsnr2 = Column(Float)
+    objectidps3 = Column(Float)
+    sgmag3 = Column(Float)
+    srmag3 = Column(Float)
+    simag3 = Column(Float)
+    szmag3 = Column(Float)
+    sgscore3 = Column(Float)
+    distpsnr3 = Column(Float)
+    nmtchps = Column(Integer, nullable=False)
+    unique1 = Column(Boolean, nullable=False)
+    unique2 = Column(Boolean, nullable=False)
+    unique3 = Column(Boolean, nullable=False)
+
+
+class Reference(Base):
+    __tablename__ = "reference"
+
+    oid = Column(String, ForeignKey("object.oid"), primary_key=True)
+    rfid = Column(BigInteger, primary_key=True)
+    candid = Column(BigInteger, nullable=False)
+    fid = Column(Integer, nullable=False)
+    rcid = Column(Integer)
+    field = Column(Integer)
+    magnr = Column(Float)
+    sigmagnr = Column(Float)
+    chinr = Column(Float)
+    sharpnr = Column(Float)
+    ranr = Column(Float(precision=53), nullable=False)
+    decnr = Column(Float(precision=53), nullable=False)
+    mjdstartref = Column(Float(precision=53), nullable=False)
+    mjdendref = Column(Float(precision=53), nullable=False)
+    nframesref = Column(Integer, nullable=False)
+
+    __table_args__ = (Index("ix_reference_fid", "fid", postgresql_using="btree"),)
+
+
+class Pipeline(Base):
+    __tablename__ = "pipeline"
+
+    pipeline_id = Column(String, primary_key=True)
+    step_id_corr = Column(String)
+    step_id_feat = Column(String)
+    step_id_clf = Column(String)
+    step_id_out = Column(String)
+    step_id_stamp = Column(String)
+    date = Column(DateTime, nullable=False)

--- a/scribe/README.md
+++ b/scribe/README.md
@@ -1,5 +1,14 @@
 # ALeRCE Scribe for MongoDB
 
+> **Note — the name is a fossil.** This scribe supports **two** backends chosen
+> at runtime via `DB_ENGINE` (`mongo` | `sql`). Every current deployment runs
+> the **SQL** backend (`DB_ENGINE=sql`), decoded by `mongo_scribe/sql/command/`;
+> **no MongoDB instance is deployed anywhere**. The Mongo command format below
+> still describes the Mongo dialect. Some producers emit both dialects, and the
+> SQL scribe quietly skips the Mongo-only ones — see
+> [`../MONGODB-LEGACY.md`](../MONGODB-LEGACY.md) before touching command
+> decoding.
+
 This step will process the commands published in the consumer topics and perform DB operations according to their types:
 
 ## Command Format

--- a/scribe/mongo_scribe/sql/command/commands.py
+++ b/scribe/mongo_scribe/sql/command/commands.py
@@ -202,11 +202,24 @@ class InsertDetectionsCommand(Command):
                 new_data[field] = new_data["extra_fields"][field]
         new_data = {k: v for k, v in new_data.items() if k not in exclude}
         new_data["step_id_corr"] = new_data.get("step_id_corr", step_version)
-        new_data["parent_candid"] = (
-            int(new_data["parent_candid"])
-            if new_data["parent_candid"] != "None"
-            else None
-        )
+        # parent_candid can arrive as a non-integer sentinel: "None" for a
+        # genuinely parentless detection, or "nan" when lightcurve does
+        # detections["parent_candid"].astype(str) on a NaN (a parentless first
+        # detection). It is a nullable BigInteger, so store NULL rather than let
+        # int() raise a ValueError that gets swallowed upstream and drops the
+        # whole detection. Log any *unexpected* value so other upstream bugs
+        # surface instead of being silently nulled.
+        try:
+            new_data["parent_candid"] = int(new_data["parent_candid"])
+        except (ValueError, TypeError):
+            if new_data["parent_candid"] not in ("None", "nan", "NaN", "", None):
+                logging.warning(
+                    "Unexpected parent_candid %r (oid=%s, candid=%s); storing NULL",
+                    new_data["parent_candid"],
+                    new_data.get("oid"),
+                    new_data.get("candid"),
+                )
+            new_data["parent_candid"] = None
         new_data["fid"] = fid_map[new_data["fid"]]
         return {**new_data, **self.criteria}
 

--- a/scribe/mongo_scribe/sql/command/decode.py
+++ b/scribe/mongo_scribe/sql/command/decode.py
@@ -1,5 +1,5 @@
 from json import loads
-from .exceptions import WrongFormatCommandException
+from .exceptions import WrongFormatCommandException, MongoDialectCommandException
 from .commands import (
     Command,
     InsertObjectCommand,
@@ -69,4 +69,14 @@ def command_factory(msg: str) -> Command:
         return InsertForcedPhotometryCommand(**message)
     if type_ == "insert" and table == "score":
         return UpsertScoreCommand(**message)
+    if type_ == "update" and table == "object":
+        # Legacy dual-DB fossil: magstats_step (and historically others) still
+        # emit the Mongo-dialect object update -- a generic
+        # {"type": "update", "collection": "object"} carrying object stats -- for
+        # a MongoDB backend that no longer exists. The SQL scribe has no handler
+        # for it (the same stats arrive via the "upsert"/magstats and
+        # "update_object_from_stats" commands), so raise a *distinct* exception
+        # the step skips quietly, rather than the generic ValueError below that
+        # it WARNs + logs the full payload for. See MONGODB-LEGACY.md.
+        raise MongoDialectCommandException(type_, table)
     raise ValueError(f"Unrecognized command type {type_} in table {table}.")

--- a/scribe/mongo_scribe/sql/command/exceptions.py
+++ b/scribe/mongo_scribe/sql/command/exceptions.py
@@ -32,3 +32,22 @@ class NoTableProvidedException(ValueError):
 
     def __init__(self):
         super().__init__("No table provided in the command")
+
+
+class MongoDialectCommandException(ValueError):
+    """
+    Raised for a legacy Mongo-dialect command that the SQL scribe intentionally
+    ignores -- currently the generic object update
+    ``{"type": "update", "collection": "object"}`` (with no ``xmatch`` in data)
+    that magstats_step still emits for the retired MongoDB backend.
+
+    It subclasses ValueError so any existing ``except ValueError`` handler still
+    treats it as a dropped command; the step catches it *first* to skip it
+    quietly instead of logging it as an invalid drop. See ``../../step.py`` and
+    the repo-root ``MONGODB-LEGACY.md``.
+    """
+
+    def __init__(self, type_, table):
+        super().__init__(
+            f"Ignoring legacy Mongo-dialect command: {type_} in table {table}."
+        )

--- a/scribe/mongo_scribe/step.py
+++ b/scribe/mongo_scribe/step.py
@@ -37,7 +37,15 @@ class MongoScribe(GenericStep):
                 new_command = self.command_factory(message["payload"])
                 valid_commands.append(new_command)
             except ValueError as e:
-                self.logger.debug(e)
+                # A command that fails to build is dropped and its offset still
+                # commits, so this log is the only trace of the lost payload.
+                # Emit it at WARN with the payload to catch other latent
+                # command-build bugs instead of losing them silently at DEBUG.
+                self.logger.warning(
+                    "Dropping invalid command: %s | payload=%s",
+                    e,
+                    message["payload"],
+                )
                 n_invalid_commands += 1
 
         logging.info(

--- a/scribe/mongo_scribe/step.py
+++ b/scribe/mongo_scribe/step.py
@@ -4,6 +4,7 @@ from .mongo.command.decode import db_command_factory as mongo_command_factory
 from .mongo.db.executor import ScribeCommandExecutor
 
 from .sql.command.decode import command_factory as sql_command_factory
+from .sql.command.exceptions import MongoDialectCommandException
 from .sql.db.executor import SQLCommandExecutor
 
 
@@ -31,11 +32,19 @@ class MongoScribe(GenericStep):
         DB Commands and executes them when they're valid.
         """
         logging.info("Processing messages...")
-        valid_commands, n_invalid_commands = [], 0
+        valid_commands, n_invalid_commands, n_mongo_dialect = [], 0, 0
         for message in messages:
             try:
                 new_command = self.command_factory(message["payload"])
                 valid_commands.append(new_command)
+            except MongoDialectCommandException:
+                # Expected legacy fossil: a Mongo-dialect command with no SQL
+                # handler and no live Mongo backend to consume it (see
+                # sql/command/decode.py and MONGODB-LEGACY.md). Skip it quietly
+                # so the WARN below stays a meaningful signal for genuine drops
+                # (e.g. a command that fails to build) rather than being drowned
+                # by the per-object magstats object update.
+                n_mongo_dialect += 1
             except ValueError as e:
                 # A command that fails to build is dropped and its offset still
                 # commits, so this log is the only trace of the lost payload.
@@ -48,9 +57,15 @@ class MongoScribe(GenericStep):
                 )
                 n_invalid_commands += 1
 
-        logging.info(
-            f"Processed {len(valid_commands)} messages successfully. Found {n_invalid_commands} invalid messages."
+        summary = (
+            f"Processed {len(valid_commands)} messages successfully. "
+            f"Found {n_invalid_commands} invalid messages."
         )
+        if n_mongo_dialect:
+            summary += (
+                f" Skipped {n_mongo_dialect} legacy Mongo-dialect commands."
+            )
+        logging.info(summary)
 
         if len(valid_commands) > 0:
             logging.info("Writing commands into database")

--- a/scribe/pyproject.toml
+++ b/scribe/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scribe"
-version = "27.5.7a37"
+version = "27.5.7a38"
 description = "Mongo scribe"
 authors = []
 readme = "README.md"

--- a/scribe/pyproject.toml
+++ b/scribe/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scribe"
-version = "27.5.7a38"
+version = "27.5.7a39"
 description = "Mongo scribe"
 authors = []
 readme = "README.md"

--- a/scribe/scripts/run_step.py
+++ b/scribe/scripts/run_step.py
@@ -27,7 +27,6 @@ logging.basicConfig(
 )
 
 
-from apf.metrics.prometheus import PrometheusMetrics
 from mongo_scribe import MongoScribe
 from prometheus_client import start_http_server
 
@@ -54,11 +53,14 @@ if use_profiling:
         application_name="step.ScribeStep", server_address=pyroscope_server
     )
 # PROMETHEUS
-prometheus_metrics = PrometheusMetrics()
+# apf's GenericStep already builds its default PrometheusMetrics at import time
+# (registered against the global REGISTRY), so creating a second one here raises
+# "Duplicated timeseries". The apf param was also renamed prometheus_metrics ->
+# metrics and GenericStep takes no **kwargs, so we let MongoScribe use apf's
+# default and pass no metrics kwarg (mirrors scribe_multisurvey/scripts/run_step.py).
+# start_http_server serves that same global registry.
 if STEP_CONFIG.get("FEATURE_FLAGS", {}).get("PROMETHEUS"):
     start_http_server(8000)
 
-step = MongoScribe(
-    config=STEP_CONFIG, db=db_type, prometheus_metrics=prometheus_metrics
-)
+step = MongoScribe(config=STEP_CONFIG, db=db_type)
 step.start()

--- a/scribe/tests/integration/test_step_sql.py
+++ b/scribe/tests/integration/test_step_sql.py
@@ -196,6 +196,78 @@ class PsqlIntegrationTest(unittest.TestCase):
             assert oids == inserted_oids
             assert candids == inserted_candids
 
+    def test_insert_detection_with_nan_parent_candid_lands_as_null(self):
+        # Regression: lightcurve does detections["parent_candid"].astype(str),
+        # so a parentless detection arrives with parent_candid == "nan". The old
+        # code did int(parent_candid), which raised ValueError on "nan"; the step
+        # swallowed the ValueError and committed the offset, silently DROPPING the
+        # detection. It must now land with parent_candid = NULL instead of being lost.
+        oid = "ZTFnanparent"
+        candid = 999000001
+        command = {
+            "collection": "detection",
+            "type": "update",
+            "criteria": {"candid": candid, "oid": oid},
+            "data": {
+                "aid": "ALnanparent",
+                "corrected": False,
+                "dec": 1.0,
+                "dubious": False,
+                "e_dec": 1.0,
+                "e_mag": 1.0,
+                "e_mag_corr": None,
+                "e_mag_corr_ext": None,
+                "e_ra": 1.0,
+                "extra_fields": {"unused": None},
+                "fid": "r",
+                "has_stamp": True,
+                "isdiffpos": 1,
+                "mag": 1.0,
+                "mag_corr": None,
+                "mjd": 50001.0,
+                "oid": oid,
+                "parent_candid": "nan",
+                "pid": 1,
+                "ra": 1.0,
+                "sid": "ZTF",
+                "stellar": False,
+                "tid": "ZTF",
+                "step_id_corr": "test",
+            },
+        }
+        with self.db.session() as session:
+            session.execute(
+                text(
+                    f"""INSERT INTO object(oid, ndet, firstmjd, g_r_max, g_r_mean_corr, meanra, meandec, step_id_corr, \
+                    lastmjd, deltajd, ncovhist, ndethist, corrected, stellar)
+                    VALUES ('{oid}', 1, 50001, 1.0, 0.9, 45, 45, 'v1', 50001, 0, 1, 1, false, false) ON CONFLICT DO NOTHING"""
+                )
+            )
+            session.commit()
+
+        # Don't pollute the shared detection/object tables for the other tests
+        # (test_insert_detections_into_database asserts on the full table). Runs
+        # even if the assertions below fail, so it can't cascade.
+        def _cleanup():
+            with self.db.session() as session:
+                session.execute(text(f"DELETE FROM detection WHERE oid = '{oid}'"))
+                session.execute(text(f"DELETE FROM object WHERE oid = '{oid}'"))
+                session.commit()
+
+        self.addCleanup(_cleanup)
+
+        self.producer.produce({"payload": json.dumps(command)})
+        self.step.start()
+        with self.db.session() as session:
+            result = list(
+                session.execute(
+                    text(
+                        f"SELECT candid, parent_candid FROM detection WHERE oid = '{oid}' AND candid = {candid}"
+                    )
+                )
+            )
+        assert len(result) == 1, "detection with parent_candid='nan' was dropped (regression)"
+        assert result[0][1] is None, f"parent_candid should be NULL, got {result[0][1]!r}"
 
     def test_upsert_non_detections(self):
         command = {

--- a/scribe/tests/unittest/test_decode_sql.py
+++ b/scribe/tests/unittest/test_decode_sql.py
@@ -1,0 +1,67 @@
+import json
+import unittest
+
+from mongo_scribe.sql.command.decode import command_factory
+from mongo_scribe.sql.command.exceptions import MongoDialectCommandException
+from mongo_scribe.sql.command.commands import UpsertXmatchCommand
+
+
+def _payload(command: dict) -> str:
+    return json.dumps(command)
+
+
+class SqlCommandFactoryTest(unittest.TestCase):
+    def test_mongo_dialect_object_update_is_skipped(self):
+        """The legacy Mongo-dialect object update -- a generic
+        {"type": "update", "collection": "object"} with no xmatch, still emitted
+        per-object by magstats_step for the retired MongoDB backend -- must raise
+        the distinct MongoDialectCommandException so the step skips it quietly
+        instead of WARN-flooding it as an invalid drop. See MONGODB-LEGACY.md."""
+        msg = _payload(
+            {
+                "type": "update",
+                "collection": "object",
+                "criteria": {"_id": "ZTF18abdlcao"},
+                "data": {"ndet": 1003, "meanra": 259.34, "meandec": -20.38},
+                "options": {"upsert": True},
+            }
+        )
+        with self.assertRaises(MongoDialectCommandException):
+            command_factory(msg)
+
+    def test_mongo_dialect_exception_is_a_valueerror(self):
+        """Subclassing ValueError keeps it backward-compatible: any caller that
+        still does `except ValueError` treats it as a (silently) dropped command
+        rather than letting it crash the batch."""
+        self.assertTrue(issubclass(MongoDialectCommandException, ValueError))
+
+    def test_genuinely_unknown_command_still_raises_plain_valueerror(self):
+        """A real unknown command must NOT be classified as a Mongo-dialect
+        fossil -- it still raises the plain ValueError the step WARNs + logs the
+        payload for, so latent command-build bugs keep surfacing."""
+        msg = _payload(
+            {"type": "mock", "collection": "object", "data": {"field": "value"}}
+        )
+        with self.assertRaisesRegex(ValueError, "Unrecognized command"):
+            command_factory(msg)
+        with self.assertRaises(ValueError) as ctx:
+            command_factory(msg)
+        self.assertNotIsInstance(ctx.exception, MongoDialectCommandException)
+
+    def test_object_update_with_xmatch_still_routes(self):
+        """Guards ordering: the xmatch branch must win over the new
+        Mongo-dialect catch-all, so an object update carrying xmatch still builds
+        an UpsertXmatchCommand rather than being skipped."""
+        msg = _payload(
+            {
+                "type": "update",
+                "collection": "object",
+                "criteria": {"_id": "ZTF18abdlcao"},
+                "data": {"xmatch": {"allwise": {"catoid": "W1", "dist": 0.1}}},
+            }
+        )
+        self.assertIsInstance(command_factory(msg), UpsertXmatchCommand)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two coupled root causes made **ZTF-legacy detections silently vanish** from Postgres and crash-loop `metadata_step` on the resulting FK orphans. This PR fixes both.

### 1. scribe drops detections with `parent_candid="nan"`
`lightcurve` emits `detections["parent_candid"].astype(str)`, so a parentless first detection arrives as the **string `"nan"`**. `InsertDetectionsCommand._format_data` only special-cased `"None"`; `int("nan")` raised `ValueError`, which `MongoScribe.execute` **swallowed at DEBUG while still committing the Kafka offset** → the detection was dropped with no trace and never retried.

- **`scribe/mongo_scribe/sql/command/commands.py`** — wrap `int(parent_candid)` in `try/except`, storing `NULL` for the known sentinels (`"None"`/`"nan"`/`""`); `parent_candid` is a nullable `BigInteger`, so `NULL` is legal. WARN on any *unexpected* value so other latent upstream bugs surface instead of being silently nulled.
- **`scribe/mongo_scribe/step.py`** — raise the invalid-command swallow from DEBUG → **WARN** and include the payload, since a dropped command's offset still commits and this log is the only trace of the lost message.
- **`scribe/tests/integration/test_step_sql.py`** — add `test_insert_detection_with_nan_parent_candid_lands_as_null` (self-cleaning, order-independent) proving the detection now lands as `NULL` instead of being dropped.

### 2. `libs/db-plugins/.../models.py` was corrupted, orphaning every legacy step
Commit `09587bc6c` ("create step for multisurvey correction") **also rewrote the *legacy* `models.py`** with a half-migrated multisurvey schema, dropping `Feature`/`MagStats`/`Probability`/`Xmatch`/`Score`/etc. Nothing consumes the multisurvey models from this legacy module (the multisurvey steps use **`db-plugins-multisurvey`**'s `models_pipeline`), so the edit only orphaned every legacy step and **hard-crashed scribe on import**. Restore `models.py` to `09587bc6c~1`.

## Testing
- **scribe** SQL integration: **11/11** (10 original + the new nan regression)
- **db-plugins** integration: **4/4**; SQL + mongo unit: **29/29**
- The 4 `cli/test_manage.py` failures (`KeyError('CONSUMER_SERVER')`) are **pre-existing and unrelated** — proven by reverting the models restore and getting identical failures.

## Notes for reviewers
- The `models.py` diff is large (779 lines) but is a **pure revert** to `09587bc6c~1` — no new schema, just the legacy schema restored.
- This stops *future* drops. Detections already lost still need a separate replay to recover before the source data ages out.